### PR TITLE
Introduce separate data channels for each local service instance element

### DIFF
--- a/docs/architecture/local_and_remote_services.drawio
+++ b/docs/architecture/local_and_remote_services.drawio
@@ -1,0 +1,194 @@
+<mxfile host="65bd71144e">
+    <diagram name="Page-1" id="hErgMLgzxy0dRG6EBmob">
+        <mxGraphModel dx="1449" dy="691" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-4" value="App1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="1" vertex="1">
+                    <mxGeometry x="-100" y="150" width="120" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-5" value="App2" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="565" width="120" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-6" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="45" width="330" height="270" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-25" value="SOME/IP" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;startArrow=classic;startFill=1;fontSize=15;fontStyle=1;strokeWidth=3;" parent="1" edge="1" target="IjG2ad2y8T5EzheXhfuq-19" source="IjG2ad2y8T5EzheXhfuq-9">
+                    <mxGeometry x="0.2" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                        <mxPoint x="910" y="280" as="sourcePoint"/>
+                        <mxPoint x="880" y="545" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-13" value="gatewayd" style="text;strokeColor=none;align=center;fillColor=none;html=1;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="510" y="50" width="30" height="10" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-15" value="" style="endArrow=none;dashed=1;html=1;dashPattern=1 3;strokeWidth=4;rounded=0;fillColor=#f8cecc;strokeColor=#b85450;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-110" y="403" as="sourcePoint"/>
+                        <mxPoint x="954" y="403" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-16" value="Network" style="text;strokeColor=none;align=center;fillColor=none;html=1;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="555" y="370" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-22" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="470" width="330" height="250" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="for each element&lt;br&gt;(event/method)" style="edgeStyle=none;html=1;entryX=0;entryY=0.75;entryDx=0;entryDy=0;startArrow=classic;startFill=1;endArrow=none;endFill=0;" parent="1" source="2" target="IjG2ad2y8T5EzheXhfuq-7" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="remote_service_instances" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="337.5" y="190" width="155" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="local_service_instances" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="337.5" y="80" width="155" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="" style="group" parent="1" vertex="1" connectable="0">
+                    <mxGeometry x="820" y="140" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-7" value="someipd" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="4" vertex="1">
+                    <mxGeometry width="150" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-8" value="vsomeip" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="4" vertex="1">
+                    <mxGeometry y="60" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-9" value="dsomeip" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" parent="4" vertex="1">
+                    <mxGeometry x="50" y="60" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-10" value="..." style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" parent="4" vertex="1">
+                    <mxGeometry x="100" y="60" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="5" value="" style="group" parent="1" vertex="1" connectable="0">
+                    <mxGeometry x="820" y="545" width="150" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-17" value="someipd" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" parent="5" vertex="1">
+                    <mxGeometry y="20" width="150" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-18" value="vsomeip" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" parent="5" vertex="1">
+                    <mxGeometry width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-19" value="dsomeip" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" parent="5" vertex="1">
+                    <mxGeometry x="50" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="IjG2ad2y8T5EzheXhfuq-20" value="..." style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;" parent="5" vertex="1">
+                    <mxGeometry x="100" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="7" value="gatewayd" style="text;whiteSpace=wrap;" parent="1" vertex="1">
+                    <mxGeometry x="495" y="480" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="28" value="for each element&lt;br&gt;(event/method)" style="edgeStyle=none;html=1;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" edge="1" parent="1" source="8" target="IjG2ad2y8T5EzheXhfuq-17">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="8" value="local_service_instances" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="337.5" y="510" width="155" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="27" style="edgeStyle=none;html=1;entryX=1;entryY=0.75;entryDx=0;entryDy=0;" edge="1" parent="1" source="9" target="IjG2ad2y8T5EzheXhfuq-5">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" value="remote_service_instances" style="rounded=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="337.5" y="620" width="155" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" style="edgeStyle=none;html=1;startArrow=none;startFill=0;" parent="1" source="IjG2ad2y8T5EzheXhfuq-4" target="3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="10" value="provides" style="edgeStyle=orthogonalEdgeStyle;html=1;entryX=0;entryY=0.25;entryDx=0;entryDy=0;dashed=1;dashPattern=8 8;fillColor=#f8cecc;strokeColor=#b85450;" parent="1" source="IjG2ad2y8T5EzheXhfuq-4" target="3" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-20" y="95"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="12" style="edgeStyle=none;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;startArrow=classic;startFill=1;endArrow=none;endFill=0;" parent="1" source="IjG2ad2y8T5EzheXhfuq-4" target="2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="for each element&lt;br&gt;(event/method)" style="edgeStyle=none;html=1;entryX=0.003;entryY=0.373;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="3" target="IjG2ad2y8T5EzheXhfuq-7" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="130" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="16" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="190" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="270" y="190" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="270" y="100" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="492.5" y="95" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="492.5" y="210" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="751" y="190" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="760" y="130" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="provides" style="edgeStyle=orthogonalEdgeStyle;html=1;dashed=1;dashPattern=8 8;fillColor=#d5e8d4;strokeColor=#82b366;" parent="1" source="IjG2ad2y8T5EzheXhfuq-5" target="8" edge="1">
+                    <mxGeometry x="-0.2941" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="150" y="440"/>
+                            <mxPoint x="415" y="440"/>
+                        </Array>
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="24" value="provides" style="edgeStyle=orthogonalEdgeStyle;html=1;fillColor=#d5e8d4;strokeColor=#82b366;dashed=1;dashPattern=8 8;" parent="1" source="IjG2ad2y8T5EzheXhfuq-5" target="2" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="130" y="240"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="11" value="provides" style="edgeStyle=orthogonalEdgeStyle;html=1;dashed=1;dashPattern=8 8;fillColor=#f8cecc;strokeColor=#b85450;" parent="1" source="IjG2ad2y8T5EzheXhfuq-4" target="9" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="-40" y="650"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="26" style="edgeStyle=none;html=1;" edge="1" parent="1" source="IjG2ad2y8T5EzheXhfuq-5" target="8">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="29" value="for each element&lt;br&gt;(event/method)" style="edgeStyle=none;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="IjG2ad2y8T5EzheXhfuq-17" target="9">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" value="IPC" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=15;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="150" y="160" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="IPC" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=15;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="590" y="160" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="32" value="IPC" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=15;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="190" y="580" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" value="IPC" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=15;fontStyle=1" vertex="1" parent="1">
+                    <mxGeometry x="590" y="580" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="760" y="545" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="35" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="150" y="620" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="160" y="545" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="37" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="495" y="515" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="38" value="Skeletons" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="760" y="610" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="39" value="Proxies" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="495" y="650" width="60" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/src/gatewayd/etc/gatewayd_config.fbs
+++ b/src/gatewayd/etc/gatewayd_config.fbs
@@ -7,6 +7,7 @@ table Root {
 
 table ServiceInstance {
     someip_service_id: uint16 (key);
+    someip_service_instance_id: uint16 = 0xFFFF;
     someip_service_version_major: uint8;
     someip_service_version_minor: uint32 = 0xFFFFFFFF;
     instance_specifier: string (required);

--- a/src/gatewayd/etc/gatewayd_config.json
+++ b/src/gatewayd/etc/gatewayd_config.json
@@ -1,17 +1,25 @@
 {
     "local_service_instances": [
         {
+            "someip_service_id": 6433,
+            "someip_service_instance_id": 1,
+            "someip_service_version_major": 1,
             "instance_specifier": "gatewayd/application_window_control",
             "events": [
                 {
+                    "someip_method_id": 2,
                     "event_name": "window_control"
                 }
             ]
         },
         {
+            "someip_service_id": 7000,
+            "someip_service_instance_id": 1,
+            "someip_service_version_major": 1,
             "instance_specifier": "gatewayd/application_echo_request",
             "events": [
                 {
+                    "someip_method_id": 0,
                     "event_name": "echo_request_tiny"
                 }
             ]
@@ -19,9 +27,13 @@
     ],
     "remote_service_instances": [
         {
+            "someip_service_id": 7001,
+            "someip_service_instance_id": 1,
+            "someip_service_version_major": 1,
             "instance_specifier": "gatewayd/application_echo_response",
             "events": [
                 {
+                    "someip_method_id": 0,
                     "event_name": "echo_response_tiny"
                 }
             ]

--- a/src/gatewayd/etc/mw_com_config.json
+++ b/src/gatewayd/etc/mw_com_config.json
@@ -118,7 +118,7 @@
   ],
   "serviceInstances": [
     {
-      "instanceSpecifier": "gatewayd/gatewayd_messages",
+      "instanceSpecifier": "SomeipMessage_6433_1_2",
       "serviceTypeName": "/gatewayd/SomeipMessageService",
       "version": {
         "major": 1,
@@ -127,6 +127,28 @@
       "instances": [
         {
           "instanceId": 0,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "message",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "instanceSpecifier": "SomeipMessage_7000_1_0",
+      "serviceTypeName": "/gatewayd/SomeipMessageService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 13,
           "asil-level": "QM",
           "binding": "SHM",
           "events": [

--- a/src/gatewayd/local_service_instance.h
+++ b/src/gatewayd/local_service_instance.h
@@ -23,8 +23,22 @@
 
 namespace score::someip_gateway::gatewayd {
 
+/// \brief Instance of a locally available service
+/// \details This class represents a service instance that is provided by an application
+///          running on the same ECU. It manages the communication between the local service
+///          and the someipd daemon, which handles the actual SOME/IP network protocol.
+///          The class uses an IPC proxy for local communication with the service providing
+///          application and coordinates with the SOME/IP message skeleton to forward messages to
+///          the someipd daemon, ultimately making the local service accessible to remote ECUs.
 class LocalServiceInstance {
    public:
+    /// \brief Constructs a LocalServiceInstance
+    /// \param service_instance_config Configuration for this service instance
+    /// \param ipc_proxy Generic proxy for IPC communication with the local service
+    /// \param someip_message_skeleton Skeleton for message transfer to the someipd daemon
+    /// \details This constructor initializes a local service instance with the necessary
+    ///          components to forward local service messages to the someipd daemon, which
+    ///          then handles the SOME/IP network communication with remote ECUs.
     LocalServiceInstance(
         std::shared_ptr<const config::ServiceInstance> service_instance_config,
         score::mw::com::GenericProxy&& ipc_proxy,
@@ -32,6 +46,16 @@ class LocalServiceInstance {
         network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
             someip_message_skeleton);
 
+    /// \brief Asynchronously creates a local service instance
+    /// \param service_instance_config Configuration for the service instance to create
+    /// \param someip_message_skeleton Skeleton for message transfer to the someipd daemon
+    /// \param instances Vector to store the created local service instance
+    /// \return Result containing a FindServiceHandle on success, or an error on failure
+    /// \details This static factory method asynchronously searches for and creates a local
+    ///          service instance. It performs service discovery on the local ECU and, when
+    ///          found, constructs a LocalServiceInstance object and adds it to the instances
+    ///          vector. The returned FindServiceHandle can be used to manage the asynchronous
+    ///          operation.
     static Result<mw::com::FindServiceHandle> CreateAsyncLocalService(
         std::shared_ptr<const config::ServiceInstance> service_instance_config,
         network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
@@ -44,8 +68,11 @@ class LocalServiceInstance {
     LocalServiceInstance& operator=(LocalServiceInstance&&) = delete;
 
    private:
+    /// Configuration for this service instance
     std::shared_ptr<const config::ServiceInstance> service_instance_config_;
+    /// Generic proxy for IPC communication with the local service providing application
     score::mw::com::GenericProxy ipc_proxy_;
+    /// Reference to the SOME/IP message skeleton for forwarding messages to the someipd daemon
     network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
         someip_message_skeleton_;
 };

--- a/src/gatewayd/local_service_instance.h
+++ b/src/gatewayd/local_service_instance.h
@@ -35,7 +35,8 @@ class LocalServiceInstance {
     /// \brief Constructs a LocalServiceInstance
     /// \param service_instance_config Configuration for this service instance
     /// \param ipc_proxy Generic proxy for IPC communication with the local service
-    /// \param someip_message_skeleton Skeleton for message transfer to the someipd daemon
+    /// \param someip_message_skeletons Map of SomeipMessage skeletons for message transfer to the
+    /// someipd daemon
     /// \details This constructor initializes a local service instance with the necessary
     ///          components to forward local service messages to the someipd daemon, which
     ///          then handles the SOME/IP network communication with remote ECUs.
@@ -43,12 +44,14 @@ class LocalServiceInstance {
         std::shared_ptr<const config::ServiceInstance> service_instance_config,
         score::mw::com::GenericProxy&& ipc_proxy,
         // TODO: Decouple this via an interface
-        network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
-            someip_message_skeleton);
+        std::map<uint16_t,
+                 network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton>&&
+            someip_message_skeletons);
 
     /// \brief Asynchronously creates a local service instance
     /// \param service_instance_config Configuration for the service instance to create
-    /// \param someip_message_skeleton Skeleton for message transfer to the someipd daemon
+    /// \param someip_message_skeletons Map of SomeipMessage skeletons for message transfer to the
+    /// someipd daemon
     /// \param instances Vector to store the created local service instance
     /// \return Result containing a FindServiceHandle on success, or an error on failure
     /// \details This static factory method asynchronously searches for and creates a local
@@ -58,8 +61,9 @@ class LocalServiceInstance {
     ///          operation.
     static Result<mw::com::FindServiceHandle> CreateAsyncLocalService(
         std::shared_ptr<const config::ServiceInstance> service_instance_config,
-        network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
-            someip_message_skeleton,
+        std::map<uint16_t,
+                 network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton>&&
+            someip_message_skeletons,
         std::vector<std::unique_ptr<LocalServiceInstance>>& instances);
 
     LocalServiceInstance(const LocalServiceInstance&) = delete;
@@ -72,9 +76,10 @@ class LocalServiceInstance {
     std::shared_ptr<const config::ServiceInstance> service_instance_config_;
     /// Generic proxy for IPC communication with the local service providing application
     score::mw::com::GenericProxy ipc_proxy_;
-    /// Reference to the SOME/IP message skeleton for forwarding messages to the someipd daemon
-    network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton&
-        someip_message_skeleton_;
+    /// Map of SomeipMessageTransferSkeletons with event/method ID as key. One skeleton for each
+    /// service instance element to forward to the someipd daemon.
+    std::map<uint16_t, network_service::interfaces::message_transfer::SomeipMessageTransferSkeleton>
+        someip_message_skeletons_;
 };
 }  // namespace score::someip_gateway::gatewayd
 

--- a/src/gatewayd/remote_service_instance.h
+++ b/src/gatewayd/remote_service_instance.h
@@ -24,14 +24,37 @@
 
 namespace score::someip_gateway::gatewayd {
 
+/// \brief Instance of a remotely available service
+/// \details This class represents a service instance that is provided by an application
+///          running on a different ECU and offered via SOME/IP. It manages the communication
+///          between the someipd daemon and local applications that consume the remote service.
+///          The class receives messages from the someipd daemon via the SOME/IP message proxy
+///          and forwards them to local consumer applications through an IPC skeleton, making
+///          remote services accessible to applications on this ECU.
 class RemoteServiceInstance {
    public:
+    /// \brief Constructs a RemoteServiceInstance
+    /// \param service_instance_config Configuration for this service instance
+    /// \param ipc_skeleton IPC skeleton for communication with local consumer applications
+    /// \param someip_message_proxy Proxy for receiving messages from the someipd daemon
+    /// \details This constructor initializes a remote service instance with the necessary
+    ///          components to receive messages from the someipd daemon and forward them to
+    ///          local applications via IPC.
     RemoteServiceInstance(std::shared_ptr<const config::ServiceInstance> service_instance_config,
                           // TODO: Use something generic (template)?
                           echo_service::EchoResponseSkeleton&& ipc_skeleton,
                           network_service::interfaces::message_transfer::SomeipMessageTransferProxy
                               someip_message_proxy);
 
+    /// \brief Asynchronously creates a remote service instance
+    /// \param service_instance_config Configuration for the service instance to create
+    /// \param instances Vector to store the created remote service instance
+    /// \return Result containing a FindServiceHandle on success, or an error on failure
+    /// \details This static factory method asynchronously searches for and creates a remote
+    ///          service instance. It performs service discovery for services offered via SOME/IP
+    ///          from remote ECUs and, when found, constructs a RemoteServiceInstance object and
+    ///          adds it to the instances vector. The returned FindServiceHandle can be used to
+    ///          manage the asynchronous operation.
     static Result<mw::com::FindServiceHandle> CreateAsyncRemoteService(
         std::shared_ptr<const config::ServiceInstance> service_instance_config,
         std::vector<std::unique_ptr<RemoteServiceInstance>>& instances);
@@ -42,8 +65,11 @@ class RemoteServiceInstance {
     RemoteServiceInstance& operator=(RemoteServiceInstance&&) = delete;
 
    private:
+    /// Configuration for this service instance
     std::shared_ptr<const config::ServiceInstance> service_instance_config_;
+    /// IPC skeleton for forwarding messages to local consumer applications
     echo_service::EchoResponseSkeleton ipc_skeleton_;
+    /// Proxy for receiving messages from the someipd daemon
     network_service::interfaces::message_transfer::SomeipMessageTransferProxy someip_message_proxy_;
 };
 }  // namespace score::someip_gateway::gatewayd

--- a/src/someipd/etc/mw_com_config.json
+++ b/src/someipd/etc/mw_com_config.json
@@ -22,7 +22,7 @@
   ],
   "serviceInstances": [
     {
-      "instanceSpecifier": "someipd/gatewayd_messages",
+      "instanceSpecifier": "SomeipMessage_6433_1_2",
       "serviceTypeName": "/gatewayd/SomeipMessageService",
       "version": {
         "major": 1,
@@ -31,6 +31,26 @@
       "instances": [
         {
           "instanceId": 0,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "message"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "instanceSpecifier": "SomeipMessage_7000_1_0",
+      "serviceTypeName": "/gatewayd/SomeipMessageService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 13,
           "asil-level": "QM",
           "binding": "SHM",
           "events": [

--- a/src/someipd/main.cpp
+++ b/src/someipd/main.cpp
@@ -26,10 +26,6 @@
 
 const char* someipd_name = "someipd";
 
-static const vsomeip::service_t service_id = 0x1111;
-static const vsomeip::instance_t service_instance_id = 0x2222;
-static const vsomeip::method_t service_method_id = 0x3333;
-
 static const std::size_t max_sample_count = 10;
 
 #define SAMPLE_SERVICE_ID 0x1234
@@ -47,6 +43,7 @@ static const std::size_t max_sample_count = 10;
 #define OTHER_SAMPLE_INSTANCE_ID 0x5422
 #define OTHER_SAMPLE_METHOD_ID 0x1421
 
+using score::mw::com::InstanceSpecifier;
 using score::someip_gateway::network_service::interfaces::message_transfer::
     SomeipMessageTransferProxy;
 using score::someip_gateway::network_service::interfaces::message_transfer::
@@ -76,11 +73,13 @@ int main(int argc, const char* argv[]) {
     }
 
     std::thread([application]() {
-        auto handles =
-            SomeipMessageTransferProxy::FindService(
-                score::mw::com::InstanceSpecifier::Create(std::string("someipd/gatewayd_messages"))
-                    .value())
-                .value();
+        // TODO: Make configuration available in someipd. Currently only available in gatewayd.
+        //       Needs to be passed from gatewayd to someipd during startup.
+        // TODO: Once configuration is available, create all SomeipMessageTransfer proxies
+        //       based on configuration instead of hardcoding here.
+        auto handles = SomeipMessageTransferProxy::FindService(
+                           InstanceSpecifier::Create(std::string("SomeipMessage_7000_1_0")).value())
+                           .value();
 
         {  // Proxy for receiving messages from gatewayd to be sent via SOME/IP
             auto proxy = SomeipMessageTransferProxy::Create(handles.front()).value();
@@ -88,8 +87,7 @@ int main(int argc, const char* argv[]) {
 
             // Skeleton for transmitting messages from the network to gatewayd
             auto create_result = SomeipMessageTransferSkeleton::Create(
-                score::mw::com::InstanceSpecifier::Create(std::string("someipd/someipd_messages"))
-                    .value());
+                InstanceSpecifier::Create(std::string("someipd/someipd_messages")).value());
             // TODO: Error handling
             auto skeleton = std::move(create_result).value();
             (void)skeleton.OfferService();


### PR DESCRIPTION
This PR introduces separate data channels (IPC connections via Proxy/Skeleton pattern, using mw::com) between the gatewayd and the someipd for each local service instance element. A local service instance is an offered service by an application running on the same ECU as the daemons. One of its elements would then be either an event or a method (or field as a composition of those). 
Therefore instead of having one single Skeleton reference for all LocalServiceInstance objects for data transmission from gatewayd to someipd, there are now multiple Skeletons as part of the LocalServiceInstance class, one for each element. 

The split into multiple data channels is done to ensure freedom from interference to a certain degree.
Furthermore scalability is another factor. Most of the SOME/IP messages will not need the full size of roughly ~1500 bytes.

The counterpart, the remote service instances shall be refactored in a similar fashion as soon as the GenericSkeleton is available from mw::com. 

Resolves #8 partially.