### PR TITLE
Add requirements docs-as-code organization structure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,10 @@ load("@score_docs_as_code//:docs.bzl", "docs")
 load("@score_tooling//:defs.bzl", "copyright_checker", "dash_license_checker", "use_format_targets")
 load("//:project_config.bzl", "PROJECT_CONFIG")
 
+# ==============================================================================
+# Compliance & Licensing
+# ==============================================================================
+
 copyright_checker(
     name = "copyright",
     srcs = [
@@ -31,20 +35,31 @@ copyright_checker(
 
 dash_license_checker(
     src = "//examples:cargo_lock",
-    file_type = "",  # let it auto-detect based on project_config
+    file_type = "",
+    # Auto-detected from project_config.
     project_config = PROJECT_CONFIG,
     visibility = ["//visibility:public"],
 )
 
-# Add target for formatting checks
+# ==============================================================================
+# Code Formatting
+# ==============================================================================
+
 use_format_targets()
+
+# ==============================================================================
+# Documentation
+# ==============================================================================
 
 docs(
     source_dir = "docs",
 )
 
-# Update python dependencies
-# Run `bazel run //:python_requirements.update` to update the lock file
+# ==============================================================================
+# Python Dependencies
+# ==============================================================================
+
+# Run `bazel run //:python_requirements.update` to update the lock file.
 compile_pip_requirements(
     name = "python_requirements",
     env_inherit = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,32 +11,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-"S-CORE SOME/IP Gateway"
-
-module(name = "score_someip_gateway")
+module(
+    name = "score_someip_gateway",
+    version = "0.0.1",
+)
 
 # ============================================================================
 # Python Configuration
 # ============================================================================
-bazel_dep(name = "rules_python", version = "1.4.1", dev_dependency = True)
-
-# rules_python 1.5.0 breaks score_docs_as_code; pin to 1.4.1 until resolved.
+bazel_dep(name = "rules_python", version = "1.5.1", dev_dependency = True)
 single_version_override(
     module_name = "rules_python",
-    version = "1.4.1",
+    version = "1.5.1",
 )
 
-# Python 3.12: Required for testing infrastructure and code generation tools
-PYTHON_VERSION = "3.12"
-
-python = use_extension(
-    "@rules_python//python/extensions:python.bzl",
-    "python",
-    dev_dependency = True,
-)
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     is_default = True,
-    python_version = PYTHON_VERSION,
+    python_version = "3.12",
 )
 use_repo(python)
 
@@ -47,14 +39,14 @@ bazel_dep(
     repo_name = "bazel_tools_python",
 )
 
-# Python pip dependencies for testing
-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
+# Python pip dependencies
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
-    hub_name = "someip_pip",
-    python_version = PYTHON_VERSION,
+    hub_name = "score_someip_gateway_pip",
+    python_version = "3.12",
     requirements_lock = "//:python_requirements_lock.txt",
 )
-use_repo(pip, "someip_pip")
+use_repo(pip, "score_someip_gateway_pip")
 
 # ============================================================================
 # Testing & Performance Measurement
@@ -63,15 +55,15 @@ bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
 bazel_dep(name = "google_benchmark", version = "1.9.4", dev_dependency = True)
 
 # ============================================================================
-# Build System Rules
+# Build System Rules & Utilities
 # ============================================================================
-bazel_dep(name = "rules_cc", version = "0.2.14")
-bazel_dep(name = "rules_rust", version = "0.63.0")
-bazel_dep(name = "rules_pkg", version = "1.1.0")
+bazel_dep(name = "bazel_lib", version = "3.1.0", dev_dependency = True)
 
-# Platforms: Standard constraint values and platform definitions
-# Required for select() expressions that use @platforms//cpu:* and @platforms//os:*
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
+bazel_dep(name = "rules_rust", version = "0.63.0")
 
 # ============================================================================
 # Toolchains & Platform Configuration
@@ -148,10 +140,10 @@ register_toolchains(
 # ============================================================================
 
 # LLVM Toolchain: C/C++ cross-compilation support for x86_64 and aarch64
-# Integrates with LLVM 19.1.0 and Debian Bullseye sysroots
+# Integrates with LLVM 19.1.7 and Debian Bullseye sysroots
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 
-# Configures LLVM 19.1.0 for C/C++ compilation with cross-architecture support.
+# Configures LLVM 19.1.7 for C/C++ compilation with cross-architecture support.
 llvm = use_extension(
     "@toolchains_llvm//toolchain/extensions:llvm.bzl",
     "llvm",
@@ -200,11 +192,15 @@ single_version_override(
 )
 
 # ============================================================================
-# Code Generation - FlatBuffers
+# Code Generation
 # ============================================================================
 bazel_dep(name = "flatbuffers", version = "25.2.10")
 
-# TRLC: Traceability Language Compiler for requirements management
+# ============================================================================
+# Requirements Traceability
+# ============================================================================
+# TRLC (Traceability Language Compiler) for requirements management.
+# Overrides the transitive dependency to pin a verified release.
 git_override(
     module_name = "trlc",
     commit = "650b51a47264a4f232b3341f473527710fc32669",  # trlc-2.0.2 release
@@ -269,10 +265,3 @@ http_archive(
         "https://github.com/COVESA/vsomeip/archive/refs/tags/3.6.1.tar.gz",
     ],
 )
-
-# ============================================================================
-# JSON Schema generation, validation and handling (e.g. write_source_files)
-# ============================================================================
-bazel_dep(name = "bazel_lib", version = "3.1.0", dev_dependency = True)
-
-bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   # Copyright (c) 2024-2026 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -19,7 +19,9 @@ SOMEIP Gateway Documentation
 .. toctree::
    :maxdepth: 2
 
+   requirements/index
    architecture/index.rst
+   tc8_conformance/index.rst
 
 
 Overview
@@ -27,18 +29,6 @@ Overview
 
 This repository provides a standardized setup for projects using **C++** or **Rust** and **Bazel** as a build system.
 It integrates best practices for build, test, CI/CD and documentation.
-
-Requirements
-------------
-
-.. stkh_req:: Example Functional Requirement
-   :id: stkh_req__docgen_enabled__example
-   :status: valid
-   :safety: QM
-   :security: YES
-   :reqtype: Functional
-   :rationale: Ensure documentation builds are possible for all modules
-
 
 Project Layout
 --------------

--- a/docs/requirements/component/index.rst
+++ b/docs/requirements/component/index.rst
@@ -1,0 +1,36 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Component Requirements
+======================
+
+Component-level requirements for the SOME/IP Gateway. Each component
+requirement derives from a feature requirement via ``:satisfies:`` and
+is scoped to a specific component (``gatewayd``, ``someipd``, or
+``network_service``).
+
+Component requirement IDs follow the format:
+``comp_req__<component>__<title_snake_case>``
+
+Assumption of Use (AoU) requirements use:
+``aou_req__<component>__<title_snake_case>``
+
+.. note::
+
+   Add component requirement files to the toctree below as they are created.
+   Use one file per component (e.g., ``gatewayd.rst``, ``someipd.rst``,
+   ``network_service.rst``).
+
+.. toctree::
+   :maxdepth: 1

--- a/docs/requirements/feature/index.rst
+++ b/docs/requirements/feature/index.rst
@@ -1,0 +1,32 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Requirements
+====================
+
+Feature-level requirements for the SOME/IP Gateway. Each feature requirement
+derives from a stakeholder requirement via ``:satisfies:`` and is scoped to
+a specific gateway capability.
+
+Feature requirement IDs follow the format:
+``feat_req__some_ip_gateway__<title_snake_case>``
+
+.. note::
+
+   Add feature requirement files to the toctree below as they are created.
+   Group requirements by feature area (e.g., ``service_discovery.rst``,
+   ``e2e_protection.rst``, ``acl.rst``).
+
+.. toctree::
+   :maxdepth: 1

--- a/docs/requirements/index.rst
+++ b/docs/requirements/index.rst
@@ -1,0 +1,126 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Requirements
+============
+
+This section contains all requirements for the SOME/IP Gateway, organized
+following the S-CORE docs-as-code requirements process.
+
+.. toctree::
+   :maxdepth: 2
+
+   stakeholder
+   feature/index
+   component/index
+
+Organization
+------------
+
+Requirements are structured in a three-level hierarchy following the
+S-CORE requirements engineering process:
+
+.. list-table:: Requirements Hierarchy
+   :widths: 20 30 50
+   :header-rows: 1
+
+   * - Level
+     - Directory
+     - Purpose
+   * - Stakeholder
+     - ``requirements/stakeholder.rst``
+     - High-level needs and constraints from users, integrators, and safety
+   * - Feature
+     - ``requirements/feature/``
+     - Derived from stakeholder requirements, scoped to a gateway feature
+   * - Component
+     - ``requirements/component/``
+     - Derived from feature requirements, scoped to a specific component
+
+Component Names
+^^^^^^^^^^^^^^^
+
+The following component identifiers are used in requirement IDs and file names:
+
+.. list-table:: Component Identifiers
+   :widths: 25 15 60
+   :header-rows: 1
+
+   * - Component
+     - Safety
+     - Description
+   * - ``gatewayd``
+     - ASIL-B
+     - Gateway daemon — bridges IPC and SOME/IP, E2E protection, ACL enforcement
+   * - ``someipd``
+     - QM
+     - SOME/IP stack daemon — wraps vsomeip, handles network I/O and SOME/IP-SD
+   * - ``network_service``
+     - ASIL-B
+     - IPC interface between ``gatewayd`` and ``someipd`` (SomeipMessageTransfer)
+
+Requirement Identifier Scheme
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+IDs follow the pattern ``<type>__<scope>__<title_snake_case>``:
+
+.. list-table:: Identifier Format
+   :widths: 20 40 40
+   :header-rows: 1
+
+   * - Type Prefix
+     - Format
+     - Example
+   * - ``stkh_req``
+     - ``stkh_req__some_ip_gateway__<title>``
+     - ``stkh_req__some_ip_gateway__transparent_bridging``
+   * - ``feat_req``
+     - ``feat_req__some_ip_gateway__<title>``
+     - ``feat_req__some_ip_gateway__e2e_protection``
+   * - ``comp_req``
+     - ``comp_req__<component>__<title>``
+     - ``comp_req__gatewayd__msg_routing``
+   * - ``aou_req``
+     - ``aou_req__<component>__<title>``
+     - ``aou_req__gatewayd__valid_config``
+
+Document Heading Standards
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All RST requirement files follow this structure:
+
+1. Copyright header (RST comment block)
+2. Document title — ``=`` overline/underline
+3. Descriptive introduction paragraph
+4. Requirement directives grouped by topic
+5. Sections within a file use ``-`` underline, subsections use ``^``
+
+Mandatory Attributes
+^^^^^^^^^^^^^^^^^^^^
+
+Every requirement directive must include these attributes:
+
+- ``:id:`` — unique identifier per the scheme above
+- ``:status:`` — ``valid`` or ``draft``
+- ``:safety:`` — ``QM`` or ``ASIL_B``
+- ``:security:`` — ``YES`` or ``NO``
+- ``:reqtype:`` — ``Functional``, ``Interface``, ``Process``, or ``Non-Functional``
+- ``:satisfies:`` — parent requirement ID (mandatory for feature and component levels)
+- ``:rationale:`` — justification text (mandatory for stakeholder level only)
+
+Cross-References
+^^^^^^^^^^^^^^^^
+
+- TC8 conformance test requirements are maintained in :doc:`/tc8_conformance/index`
+  alongside their test specifications.

--- a/docs/requirements/stakeholder.rst
+++ b/docs/requirements/stakeholder.rst
@@ -1,0 +1,35 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Stakeholder Requirements
+========================
+
+This file contains stakeholder-level requirements for the SOME/IP Gateway.
+Stakeholder requirements capture high-level needs from users, integrators,
+and safety standards. They are the top of the requirements hierarchy —
+feature and component requirements derive from these.
+
+.. stkh_req:: Example Functional Requirement
+   :id: stkh_req__docgen_enabled__example
+   :status: valid
+   :safety: QM
+   :security: YES
+   :reqtype: Functional
+   :rationale: Ensure documentation builds are possible for all modules
+
+.. note::
+
+   The requirement above is a placeholder inherited from the module template.
+   It should be replaced with proper SOME/IP Gateway stakeholder requirements
+   as they are defined.

--- a/docs/tc8_conformance/index.rst
+++ b/docs/tc8_conformance/index.rst
@@ -1,0 +1,28 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+TC8 SOME/IP Conformance Testing
+================================
+
+This section defines the requirements, test specifications, and traceability
+for OPEN Alliance TC8 SOME/IP conformance testing of the ``someipd``
+component (vsomeip 3.6.1 stack).
+
+All tests are **application-less** — they exercise the SOME/IP protocol stack
+directly at the wire level without requiring ``gatewayd`` or application processes.
+
+.. toctree::
+   :maxdepth: 2
+
+   requirements.rst

--- a/docs/tc8_conformance/requirements.rst
+++ b/docs/tc8_conformance/requirements.rst
@@ -1,0 +1,248 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+TC8 Conformance Test Requirements
+==================================
+
+Feature Requirement
+-------------------
+
+The following feature requirement establishes TC8 SOME/IP conformance testing
+as a formal verification activity for the SOME/IP Gateway's protocol stack.
+
+.. feat_req:: TC8 SOME/IP Protocol Conformance
+   :id: feat_req__some_ip_gateway__tc8_conformance
+   :status: valid
+   :tags: tc8, conformance, someip, verification
+   :satisfies: stkh_req__docgen_enabled__example
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The SOME/IP Gateway project shall verify protocol conformance of its
+   SOME/IP stack (``someipd``) against OPEN Alliance TC8 SOME/IP test
+   specifications at the wire protocol level, without requiring application
+   processes.
+
+   Note: The ``:satisfies:`` link targets a placeholder stakeholder requirement.
+   This shall be updated to reference the upstream S-CORE stakeholder requirement
+   for SOME/IP interoperability once it is formally defined.
+
+Component Requirements — Service Discovery
+-------------------------------------------
+
+The following component requirements define the high-priority TC8 conformance
+tests for SOME/IP Service Discovery (SD), aligned with SOME/IP-SD Protocol
+Specification (AUTOSAR PRS_SOMEIP_SD).
+
+.. comp_req:: TC8 SD Offer Entry Format Validation
+   :id: comp_req__someipd__tc8_sd_offer_format
+   :status: valid
+   :tags: tc8, conformance, service_discovery
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` transmits
+   SOME/IP-SD OfferService entries on the configured multicast group
+   with correct service ID, instance ID, major/minor version, and TTL
+   fields upon startup.
+
+   Note: Traces to SOME/IP-SD specification sections 4.1.2.1
+   (OfferService entry format) and 4.1.2.3 (Service Entry fields).
+   Covers TC8-SD-001 and TC8-SD-002 from the test strategy.
+
+.. comp_req:: TC8 SD Cyclic Offer Timing
+   :id: comp_req__someipd__tc8_sd_cyclic_timing
+   :status: valid
+   :tags: tc8, conformance, service_discovery, timing
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` repeats
+   OfferService entries at the configured ``cyclic_offer_delay`` interval
+   (±20% tolerance) during the main phase of Service Discovery.
+
+   Note: Traces to SOME/IP-SD specification section 4.1.1
+   (SD Phases — Main Phase, cyclic offer behavior).
+   Covers TC8-SD-003 from the test strategy.
+
+.. comp_req:: TC8 SD FindService Response
+   :id: comp_req__someipd__tc8_sd_find_response
+   :status: valid
+   :tags: tc8, conformance, service_discovery
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` responds to
+   a SOME/IP-SD FindService entry with a unicast OfferService for a
+   known service, and does not respond for an unknown service.
+
+   Note: Traces to SOME/IP-SD specification section 4.1.2.2
+   (FindService entry handling and response behavior).
+   Covers TC8-SD-004 and TC8-SD-005 from the test strategy.
+
+.. comp_req:: TC8 SD Subscribe Eventgroup Lifecycle
+   :id: comp_req__someipd__tc8_sd_subscribe_lifecycle
+   :status: valid
+   :tags: tc8, conformance, service_discovery, eventgroup
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` correctly
+   handles the SubscribeEventgroup lifecycle: acknowledge valid
+   subscriptions (SubscribeEventgroupAck), reject unknown eventgroups
+   (SubscribeEventgroupNack with TTL=0), and honor StopSubscribeEventgroup
+   by ceasing notifications.
+
+   Note: Traces to SOME/IP-SD specification sections 4.1.2.4
+   (SubscribeEventgroup), 4.1.2.5 (StopSubscribeEventgroup),
+   and 4.1.2.6 (SubscribeEventgroupAck/Nack).
+   Covers TC8-SD-006, TC8-SD-007, and TC8-SD-008 from the test strategy.
+
+.. comp_req:: TC8 SD Initial Delay and Repetitions Phase
+   :id: comp_req__someipd__tc8_sd_phases_timing
+   :status: valid
+   :tags: tc8, conformance, service_discovery, timing
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` observes
+   the three SD phases: initial wait delay within ``[initial_delay_min,
+   initial_delay_max]``, repetition of offers ``repetitions_max`` times
+   at ``repetitions_base_delay`` intervals, and transition to main phase.
+
+   Note: Traces to SOME/IP-SD specification section 4.1.1
+   (SD Phases — Initial Wait, Repetition, Main Phase).
+   Covers TC8-SD-009 and TC8-SD-010 from the test strategy.
+
+Component Requirements — SOME/IP Message Format
+------------------------------------------------
+
+.. comp_req:: TC8 SOME/IP Response Header Validation
+   :id: comp_req__someipd__tc8_msg_response_header
+   :status: valid
+   :tags: tc8, conformance, message_format
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` returns
+   SOME/IP RESPONSE messages with correct protocol version (0x01),
+   message type (0x80), matching session ID, and matching client ID
+   for each received REQUEST.
+
+   Note: Traces to SOME/IP specification sections 4.1.4
+   (Protocol Version), 4.1.6 (Message Type), and 4.1.3 (Request ID —
+   Client ID / Session ID). Covers TC8-SOMEIP-MSG-001,
+   TC8-SOMEIP-MSG-002, TC8-SOMEIP-MSG-005, and TC8-SOMEIP-MSG-008
+   from the test strategy.
+
+.. comp_req:: TC8 SOME/IP Error Return Codes
+   :id: comp_req__someipd__tc8_msg_error_codes
+   :status: valid
+   :tags: tc8, conformance, message_format, error_handling
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` returns
+   the correct SOME/IP return codes for error conditions:
+   ``E_UNKNOWN_SERVICE`` (0x02) for requests to non-existent services,
+   ``E_UNKNOWN_METHOD`` (0x03) for invalid method IDs, and
+   ``E_WRONG_INTERFACE_VERSION`` for interface version mismatches.
+
+   Note: Traces to SOME/IP specification section 4.1.7 (Return Code)
+   and the return code table (Table 4.14). Covers TC8-SOMEIP-MSG-003,
+   TC8-SOMEIP-MSG-004, and TC8-SOMEIP-MSG-006 from the test strategy.
+
+Component Requirements — Event Notification
+--------------------------------------------
+
+.. comp_req:: TC8 Event Notification Subscription Lifecycle
+   :id: comp_req__someipd__tc8_evt_subscription
+   :status: valid
+   :tags: tc8, conformance, events, notification
+   :satisfies: feat_req__some_ip_gateway__tc8_conformance
+   :safety: QM
+   :security: NO
+   :reqtype: Functional
+
+   The conformance test suite shall verify that ``someipd`` delivers
+   NOTIFICATION messages (message type 0x02) with correct event ID
+   only to endpoints with an active eventgroup subscription, and ceases
+   delivery after StopSubscribeEventgroup.
+
+   Note: Traces to SOME/IP specification section 5.1 (Events) and
+   SOME/IP-SD section 4.1.2.4 (SubscribeEventgroup triggering
+   notification delivery). Covers TC8-EVT-001 through TC8-EVT-004
+   and TC8-EVT-006 from the test strategy.
+
+Traceability Summary
+---------------------
+
+The following table links each component requirement to the SOME/IP
+specification section it verifies.
+
+.. list-table:: TC8 Requirement Traceability Matrix
+   :widths: 30 20 30 20
+   :header-rows: 1
+
+   * - Requirement ID
+     - TC8 Test IDs
+     - SOME/IP Spec Reference
+     - Safety
+   * - ``comp_req__someipd__tc8_sd_offer_format``
+     - TC8-SD-001, -002
+     - SOME/IP-SD §4.1.2.1, §4.1.2.3
+     - QM
+   * - ``comp_req__someipd__tc8_sd_cyclic_timing``
+     - TC8-SD-003
+     - SOME/IP-SD §4.1.1 (Main Phase)
+     - QM
+   * - ``comp_req__someipd__tc8_sd_find_response``
+     - TC8-SD-004, -005
+     - SOME/IP-SD §4.1.2.2
+     - QM
+   * - ``comp_req__someipd__tc8_sd_subscribe_lifecycle``
+     - TC8-SD-006, -007, -008
+     - SOME/IP-SD §4.1.2.4–4.1.2.6
+     - QM
+   * - ``comp_req__someipd__tc8_sd_phases_timing``
+     - TC8-SD-009, -010
+     - SOME/IP-SD §4.1.1 (Phases)
+     - QM
+   * - ``comp_req__someipd__tc8_msg_response_header``
+     - TC8-MSG-001, -002, -005, -008
+     - SOME/IP §4.1.3, §4.1.4, §4.1.6
+     - QM
+   * - ``comp_req__someipd__tc8_msg_error_codes``
+     - TC8-MSG-003, -004, -006
+     - SOME/IP §4.1.7 (Table 4.14)
+     - QM
+   * - ``comp_req__someipd__tc8_evt_subscription``
+     - TC8-EVT-001–004, -006
+     - SOME/IP §5.1, SOME/IP-SD §4.1.2.4
+     - QM

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -26,7 +26,7 @@ py_pytest(
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//src/someipd",
-        "@someip_pip//pytest",
-        "@someip_pip//someip",
+        "@score_someip_gateway_pip//pytest",
+        "@score_someip_gateway_pip//someip",
     ],
 )


### PR DESCRIPTION
This pull request introduces a three-level requirements hierarchy for the SOME/IP Gateway:

- docs/requirements/index.rst: conventions reference (folder structure, component names, identifier scheme, mandatory attributes)
- docs/requirements/stakeholder.rst: stakeholder requirements
- docs/requirements/feature/index.rst: feature requirements skeleton
- docs/requirements/component/index.rst: component requirements skeleton
- docs/tc8_conformance/: TC8 SOME/IP conformance test requirements