### PR TITLE
Add shellcheck linting via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
         args: [--maxkb=50, --enforce-all] # increase or add git lfs if too strict
         exclude: MODULE.bazel.lock|tests/benchmarks/benchmarks_analysis.md
 
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 38980559e3a605691d6579f96222c30778e5a69e # 3.0.0
+    hooks:
+      - id: shellcheck
+
   - repo: https://github.com/eclipse-score/tooling
     rev: 31ff8eee214e4e97ef8f5cb46e443273515b63ec
     hooks:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -12,15 +12,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-external-sources=true
-
-# Enable all checks as long as it works
+# Enable all optional checks as long as it works.
 # This might create surprises when updating shellcheck and it adds new checks.
 # If this becomes annoying we have to selectively enable checks
 enable=all
 
-# required checks, no reason not to fix them except difficulty and fear to break code
-disable=SC2046
+# Follow sourced files (needed for scripts that source config)
+external-sources=true
 
-# optional checks, fixes might not be easy and better not break the code
-disable=SC2292,SC2154,SC2312
+# SC2292: [[ ]] not available in #!/bin/sh scripts — legitimate false positive
+disable=SC2292

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileCopyrightText: 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+external-sources=true
+
+# Enable all checks as long as it works
+# This might create surprises when updating shellcheck and it adds new checks.
+# If this becomes annoying we have to selectively enable checks
+enable=all
+
+# required checks, no reason not to fix them except difficulty and fear to break code
+disable=SC2046
+
+# optional checks, fixes might not be easy and better not break the code
+disable=SC2292,SC2154,SC2312

--- a/deployment/run_gateway.sh
+++ b/deployment/run_gateway.sh
@@ -54,9 +54,13 @@ case "$1" in
         echo "Starting someipd..."
         # Locate vsomeip shared libraries inside the Bazel runfiles tree and
         # add them to LD_LIBRARY_PATH so the dynamic linker finds them.
+        # head -1 exit code intentionally ignored; find errors suppressed via 2>/dev/null
+        # shellcheck disable=SC2312
         VSOMEIP_LIB_DIR=$(find "${SCRIPT_DIR}/someipd.runfiles" \
             -name "libvsomeip3.so*" -exec dirname {} \; 2>/dev/null | head -1)
         if [ -n "${VSOMEIP_LIB_DIR}" ]; then
+            # LD_LIBRARY_PATH is inherited from the caller's environment
+            # shellcheck disable=SC2154
             export LD_LIBRARY_PATH="${VSOMEIP_LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         fi
         "${SCRIPT_DIR}/someipd" \

--- a/tests/integration/docker_setup/entrypoint-master
+++ b/tests/integration/docker_setup/entrypoint-master
@@ -31,7 +31,8 @@ cp /home/source/bazel-bin/src/gatewayd/etc/gatewayd_config.bin /home/source/src/
 # Give gatewayd some time to start. TODO: improve with some sort of state check
 sleep 2s
 
-export VSOMEIP_CONFIGURATION=$(pwd)/tests/integration/vsomeip.json
+VSOMEIP_CONFIGURATION="$(pwd)/tests/integration/vsomeip.json"
+export VSOMEIP_CONFIGURATION
 /home/source/bazel-bin/src/someipd/someipd -service_instance_manifest /home/source/src/someipd/etc/mw_com_config.json &
 
 # /home/source/bazel-bin/tests/benchmarks/ipc_benchmarks


### PR DESCRIPTION
This pull request adds shellcheck linting to the pre-commit pipeline, following the setup used in [eclipse-score/devcontainer](https://github.com/eclipse-score/devcontainer/blob/main/.pre-commit-config.yaml#L29-L32).

Changes:

- `.pre-commit-config.yaml` — adds the shellcheck hook from jumanjihouse/pre-commit-hooks (3.0.0)
- `.shellcheckrc` — new configuration file mirroring the devcontainer settings