### PR TITLE
fix: Update bazel cache on "merge_group" event

### DIFF
--- a/.github/workflows/build_and_test_cross_compilation.yml
+++ b/.github/workflows/build_and_test_cross_compilation.yml
@@ -43,6 +43,7 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
+          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -40,6 +40,7 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
+          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,6 +16,6 @@ on:
   workflow_call:
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -26,6 +26,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
<!--
*******************************************************************************
Copyright (c) 2026 Contributors to the Eclipse Foundation

See the NOTICE file(s) distributed with this work for additional
information regarding copyright ownership.

This program and the accompanying materials are made available under the
terms of the Apache License Version 2.0 which is available at
https://www.apache.org/licenses/LICENSE-2.0

SPDX-License-Identifier: Apache-2.0
*******************************************************************************
-->

# Bugfix

## Description

Update CICD workflows to update bazel cache on "merge_group" event.
Without it the bazel cache doesn't get updated when building from the merge queue.

## Related ticket

See eclipse-score/cicd-workflows#95
