### PR TITLE
revert: save cache from merge group events

### DIFF
--- a/.github/workflows/build_and_test_cross_compilation.yml
+++ b/.github/workflows/build_and_test_cross_compilation.yml
@@ -43,7 +43,6 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_cross_compilation.yml
+++ b/.github/workflows/build_and_test_cross_compilation.yml
@@ -43,6 +43,7 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
+          cache-save: ${{ github.event_name == 'push' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -40,7 +40,6 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
-          cache-save: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -40,6 +40,7 @@ jobs:
           repository-cache: true
           # Cache external/
           external-cache: true
+          cache-save: ${{ github.event_name == 'push' }}
       - name: Allow linux-sandbox
         uses: ./.github/actions/unblock_user_namespace_for_linux_sandbox
       - run: df -h

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,6 +16,6 @@ on:
   workflow_call:
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,6 +16,6 @@ on:
   workflow_call:
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,6 +16,6 @@ on:
   workflow_call:
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -26,6 +26,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@829b3e11ccbf924a5782f7bfed647cb1619fdf78 # v0.0.1
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -26,6 +26,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838 # main (2026-04-20)
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -26,6 +26,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@745e84d61595f0ba612ea22b682d8c69e7045654 # v0.0.1+merge_group
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838# main (2026-04-20)
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
This reverts d76583183956e8d5745d02dddad00e213d5b2887.

The used version was from a repo, whichs branch got deleted. Now workflows do not work anymore unless we start using an existing commit.

Github caches are complicated. Pull requests can use a cache that was either created by the same pull request or the main branch. Thus caches created by merge groups will not be used. On top of that each merge group run gets its own temporary branch and thus cache, which will never be reused, but consumes space.

For more information about cache sharing read [this](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache)