### PR TITLE
ci: Run workflows on pushed to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  push:
+    branches: [main]
   workflow_dispatch:
 jobs:
   pre-commit:

--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -17,6 +17,8 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
+  push:
+    branches: [main]
   workflow_dispatch:
 jobs:
   build_and_test_qnx:


### PR DESCRIPTION
In the presence of merge queues, this is not necessary, except for caching. Pull requests cannot use the cache created from merge queues, but can only use their own or that from main.

For more information about cache sharing read [this](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache)