### PR TITLE
ci: Make QNX builds optional temporarily

### DIFF
--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -51,7 +51,8 @@ jobs:
     name: ci_pull_request_target/can_merge
     if: always()
     needs:
-      - build_and_test_qnx
+      # No need to pass as long as SDK download is unstable
+      # - build_and_test_qnx
       - docs
       - license_check
     permissions:


### PR DESCRIPTION
SDK downloads fails a lot, which prevents us from doing any progress. Until the SDK download is stable a failing QNX build will not block us merging to main.