### PR TITLE
chore(deps): bump eclipse-score/cicd-workflows

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,6 +16,6 @@ on:
   workflow_call:
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -20,10 +20,10 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs every day at midnight UTC
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -23,9 +23,8 @@ permissions:
   pull-requests: write
   issues: write
 
-
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@89a04e651b3223eb30b9071eb31f428f380bf47d # main (2026-04-23)
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@186ace77e09aa61bda581e5130aca70b7ec3ed06 # main (2026-05-06)
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
<!--
*******************************************************************************
Copyright (c) 2026 Contributors to the Eclipse Foundation

See the NOTICE file(s) distributed with this work for additional
information regarding copyright ownership.

This program and the accompanying materials are made available under the
terms of the Apache License Version 2.0 which is available at
https://www.apache.org/licenses/LICENSE-2.0

SPDX-License-Identifier: Apache-2.0
*******************************************************************************
-->

# Improvement

## Description

This reduces the number of caches created by the docs workflow
