### PR TITLE
fix: Fix README and BUILD files for 'configuration' cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bazel run //src/gatewayd:gatewayd_example
 and in a separate terminal
 
 ```sh
-bazel run //src/someipd
+bazel run //src/someipd:someipd_example
 ```
 
 ### Run Example app
@@ -73,7 +73,7 @@ Start up the containers:
 docker compose --project-directory tests/integration/docker_setup/ up
 ```
 
-Those containers are pre-configured (IP adresses, multicast route, ...).
+Those containers are pre-configured (IP addresses, multicast route, ...).
 The someipd-1 container already starts up the `gatewayd` and the `someipd`.
 
 In Wireshark the network traffic can be seen by capturing on `any` with `ip.addr== 192.168.87.2 || ip.addr ==192.168.87.3`.
@@ -93,19 +93,19 @@ docker exec -it docker_setup-someipd-1 /home/source/bazel-bin/tests/benchmarks/i
 
 ## 📝 Configuration
 
-### Gatewayd Config Schema Validation
+### Daemon Config Schema Validation
 
-The `gatewayd` module is configured using a flatbuffer binary file generated from a JSON file. We provide a JSON schema which helps when editing the JSON file, and can also be used to validate it.
+Both the `gatewayd` and `someipd` daemons are configured using a single flatbuffer binary file generated from a JSON file. We provide a JSON schema which helps when editing the JSON file, and can also be used to validate it.
 
 #### Configuration Schema
 
-The JSON schema for the `gatewayd` configuration is located at:
+The JSON schema for the configuration is located at:
 
 ```bash
-src/gatewayd/etc/gatewayd_config.schema.json
+src/config/mw_someip_config.schema.json
 ```
 
-This schema defines the expected properties, data types, and constraints for a valid `gatewayd_config.json` configuration file.
+This schema defines the expected properties, data types, and constraints for a valid JSON configuration file to be used for flatbuffer generation.
 
 #### Generate Configuration Binary
 
@@ -115,8 +115,8 @@ To generate a someip config binary for your project, add the following to your `
 load("@score_someip_gateway//bazel/tools:someip_config.bzl", "generate_someip_config_bin")
 generate_someip_config_bin(
     name = "<generation_rule_name>",
-    json = "//<package>:<path_to_gatewayd_config_json>",
-    output = "etc/gatewayd_config.bin",
+    json = "//<package>:<path_to_config_json>",
+    output = "<path_to_config>/<name_of_config>.bin",
 )
 ```
 
@@ -132,7 +132,9 @@ native_binary(
     name = "gatewayd",
     src = "@score_someip_gateway//src/gatewayd",
     args = [
-        "-service_instance_manifest",
+        "--configuration",
+        "$(rootpath :someipd_config)",
+        "--service_instance_manifest",
         "$(rootpath etc/mw_com_config.json)",
     ],
     data = [
@@ -142,13 +144,13 @@ native_binary(
 )
 ```
 
-Or you can manually generate the `gatewayd_config.bin` with the following command:
+Or you can manually generate the flatbuffer binary with the following command:
 
 ```bash
 bazel build //:someipd_config # if the macro has been added to root BUILD.bazel
 ```
 
-On success you can retrieve the generated `gatewayd_config.bin` from `bazel-bin/`. Check the success message for the exact path.
+On success you can retrieve the generated flatbuffer binary from `bazel-bin/`. Check the success message for the exact path.
 
 
 #### Configuration Validation

--- a/src/gatewayd/BUILD.bazel
+++ b/src/gatewayd/BUILD.bazel
@@ -77,6 +77,8 @@ native_binary(
     name = "gatewayd_example",
     src = "//src/gatewayd",
     args = [
+        "--configuration",
+        "$(rootpath //src/config:config_file)",
         "--service_instance_manifest",
         "$(rootpath etc/mw_com_config.json)",
     ],

--- a/src/someipd/BUILD.bazel
+++ b/src/someipd/BUILD.bazel
@@ -15,6 +15,7 @@
 This daemon contains the SOME/IP communication stack and is QM
 """
 
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
@@ -27,13 +28,6 @@ exports_files(["etc/mw_com_config.json"])
 cc_binary(
     name = "someipd",
     srcs = ["main.cpp"],
-    args = [
-        "--service_instance_manifest",
-        "$(rootpath etc/mw_com_config.json)",
-    ],
-    data = [
-        "etc/mw_com_config.json",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":routing",
@@ -71,4 +65,19 @@ validate_json_schema_test(
     json = "etc/mw_com_config.json",
     schema = "@score_communication//score/mw/com:config_schema",
     tags = ["lint"],
+)
+
+native_binary(
+    name = "someipd_example",
+    src = "//src/someipd",
+    args = [
+        "--configuration",
+        "$(rootpath //src/config:config_file)",
+        "--service_instance_manifest",
+        "$(rootpath etc/mw_com_config.json)",
+    ],
+    data = [
+        "etc/mw_com_config.json",
+        "//src/config:config_file",
+    ],
 )

--- a/tests/integration/docker_setup/entrypoint-master
+++ b/tests/integration/docker_setup/entrypoint-master
@@ -24,13 +24,13 @@ route add -net 224.0.0.0/4 dev eth0
 # gatewayd --> connects to car_window_controller, sets up IPC communication to someipd
 # someipd --> connects to gatewayd, sends out SOME/IP messages on the network
 
-/home/source/bazel-bin/src/gatewayd/gatewayd --service_instance_manifest /home/source/src/gatewayd/etc/mw_com_config.json --config /home/source/bazel-bin/src/config/mw_someip_config.bin &
+/home/source/bazel-bin/src/gatewayd/gatewayd --service_instance_manifest /home/source/src/gatewayd/etc/mw_com_config.json --configuration /home/source/bazel-bin/src/config/mw_someip_config.bin &
 # Give gatewayd some time to start. TODO: improve with some sort of state check
 sleep 2s
 
 VSOMEIP_CONFIGURATION="$(pwd)/tests/integration/vsomeip.json"
 export VSOMEIP_CONFIGURATION
-/home/source/bazel-bin/src/someipd/someipd --service_instance_manifest /home/source/src/someipd/etc/mw_com_config.json --config /home/source/bazel-bin/src/config/mw_someip_config.bin &
+/home/source/bazel-bin/src/someipd/someipd --service_instance_manifest /home/source/src/someipd/etc/mw_com_config.json --configuration /home/source/bazel-bin/src/config/mw_someip_config.bin &
 
 # /home/source/bazel-bin/tests/benchmarks/ipc_benchmarks
 


### PR DESCRIPTION
The usage and explanation of the introduced 'configuration' CLI argument for gatewayd and someipd was inconsistent. 

Scope of the PR:
- Update README.md to reflect the changes done for the configurable someipd
- Align gatewayd and someipd host execution via 'bazel run' using the 'native_binary' rule.
- Fix CLI argument name in the docker setup