### PR TITLE
fix: Resolve dev_dependency visibility for downstream consumers

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ module(
 # ============================================================================
 bazel_dep(name = "rules_python", version = "1.9.0", dev_dependency = True)
 
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
 
 # Required because python 3.8 support was dropped in rules_python 1.8.0, but is
 # still needed for score_bazel_tools_python 0.1.3 (latest).
@@ -46,7 +46,7 @@ bazel_dep(
 )
 
 # Python pip dependencies
-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
     hub_name = "score_someip_gateway_pip",
     python_version = "3.12",
@@ -159,8 +159,8 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = Tr
 # ============================================================================
 # JSON Schema Validation
 # ============================================================================
-bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1", dev_dependency = True)
-bazel_dep(name = "download_utils", version = "1.2.3", dev_dependency = True)
+bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
+bazel_dep(name = "download_utils", version = "1.2.3")
 
 download_archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
 
@@ -257,7 +257,7 @@ filegroup(
 
 http_archive(
     name = "vsomeip",
-    build_file = "@//:third_party/vsomeip.BUILD.bazel",
+    build_file = "//:third_party/vsomeip.BUILD.bazel",
     integrity = "sha256-hMjkJs3fQ14MVtpwupfno/UbK+rxV+1zih9632bO5Sk=",
     patch_strip = 1,
     patches = ["//:third_party/vsomeip-qnx8.patch"],

--- a/src/config/BUILD.bazel
+++ b/src/config/BUILD.bazel
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("@score_someip_gateway//bazel/tools:someip_config.bzl", "generate_someip_config_bin")
 
@@ -48,11 +47,4 @@ genrule(
     cmd = "$(location @flatbuffers//:flatc) --jsonschema -o $(@D) $(SRCS) && mv $(@D)/mw_someip_config.schema.json $@",
     tools = ["@flatbuffers//:flatc"],
     visibility = ["//visibility:public"],
-)
-
-write_source_files(
-    name = "config_schema.update",
-    files = {
-        "mw_someip_config.schema.json": ":config_schema.generate",
-    },
 )


### PR DESCRIPTION
# Improvement

## Description

When `score_someip_gateway` is consumed as a `bazel_dep` by a downstream module, four build failures occur due to incorrect `dev_dependency` annotations and a label syntax issue in `MODULE.bazel`:

1. `rules_python` `use_extension` calls were not marked `dev_dependency`, causing resolution failure against a stripped `bazel_dep`
2. `@//` in vsomeip `http_archive.build_file` resolves to the root module instead of the defining module
3. `bazel_lib` (dev-only) was loaded unconditionally in `src/config/BUILD.bazel` via `write_source_files`
4. `nlohmann_json` and `download_utils` were marked dev-only but `@json_schema_validator` is loaded in `src/gatewayd/` and `src/someipd/` BUILD files

This eliminates the need for downstream patches (e.g., in the S-CORE Reference Integration SDK).

## Related ticket

No existing issue, this was identified during downstream integration.