### PR TITLE
fix: Restore config schema sync guard removed in #144

### DIFF
--- a/src/config/BUILD.bazel
+++ b/src/config/BUILD.bazel
@@ -18,6 +18,7 @@ exports_files(
     [
         "mw_someip_config.fbs",
         "mw_someip_config.json",
+        "mw_someip_config.schema.json",
     ],
 )
 

--- a/src/config/dev/BUILD.bazel
+++ b/src/config/dev/BUILD.bazel
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+
+write_source_files(
+    name = "config_schema.update",
+    check_that_out_file_exists = False,
+    files = {
+        "//src/config:mw_someip_config.schema.json": "//src/config:config_schema.generate",
+    },
+)


### PR DESCRIPTION
# Improvement

## Description

PR #144 removed the `write_source_files` target from `src/config/BUILD.bazel` to fix a downstream `dev_dependency` visibility issue caused by the `@bazel_lib` load statement. As noted by @NEOatNHNG in a [post-merge review comment](https://github.com/eclipse-score/inc_someip_gateway/pull/144#discussion_r3389693016), this removal means the committed `mw_someip_config.schema.json` could drift out of sync with the FlatBuffers schema definition (`mw_someip_config.fbs`).

This PR restores the sync guard by moving the `write_source_files` target into a separate dev-only Bazel package (`src/config/dev/`). This way:
- `bazel_lib` remains a `dev_dependency`
- The `load("@bazel_lib//...")` only triggers when `//src/config/dev` is explicitly built
- `bazel test //src/...` includes the auto-generated `config_schema.update_test` that catches schema drift
- Developers regenerate via `bazel run //src/config/dev:config_schema.update`

## Related ticket
Addresses post-merge feedback on #144.