### PR TITLE
fix: QNX build by keeping Android SDK available

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@93aac16ada7d247bbb6ae926509ddea74cf5213a # main (2026-06-03)
+    uses: elektrobit-contrib/eclipse-score_cicd-workflows/.github/workflows/qnx-build.yml@use-more-disk-space-without-android-sdk-removal
+    # uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@93aac16ada7d247bbb6ae926509ddea74cf5213a # main (2026-06-03)
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-cross')
     secrets: inherit
     uses: ./.github/workflows/build_and_test_cross_compilation.yml
+  build_and_test_qnx:
+    # remove before merge
+    secrets: inherit
+    uses: ./.github/workflows/build_and_test_qnx.yml
+    permissions:
+      contents: read
+      pull-requests: read
   copyright:
     secrets: inherit
     uses: ./.github/workflows/copyright.yml


### PR DESCRIPTION
rules_jvm_external starting with version 6.10 needs an Android SDK. So better do not delete it.