### PR TITLE
feat: QEMU Linux integration test speedup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -325,9 +325,9 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 
 http_file(
     name = "ubuntu_24_04_cloudimg",
-    downloaded_file_path = "noble-server-cloudimg-amd64.img",
-    integrity = "sha256-X6WwXl7COYWMRTFIXWAjsIlkSMLffGOzT42ubqYFGkQ=",
-    url = "https://cloud-images.ubuntu.com/releases/noble/release-20260615/ubuntu-24.04-server-cloudimg-amd64.img",
+    downloaded_file_path = "noble-minimal-cloudimg-amd64.img",
+    integrity = "sha256-vZAj5xt7tb3tFOT7DJmODZPXFJ6QVsPmi0b/kJfdF9U=",
+    url = "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260626/ubuntu-24.04-minimal-cloudimg-amd64.img",
 )
 
 imagefs = use_extension("@score_rules_imagefs//extensions:imagefs.bzl", "imagefs", dev_dependency = True)

--- a/quality/integration_testing/environments/ubuntu24_04_qemu/BUILD
+++ b/quality/integration_testing/environments/ubuntu24_04_qemu/BUILD
@@ -16,6 +16,7 @@ exports_files(
         "qemu_config.json",
         "user-data",
         "meta-data",
+        "prepare_image.sh",
     ],
     visibility = ["//:__subpackages__"],
 )
@@ -84,5 +85,20 @@ genrule(
     outs = ["seed.img"],
     cmd = "cloud-localds -N $(location :network_config) $@ $(location user-data) $(location meta-data)",
     tags = ["manual"],
+    visibility = ["//:__subpackages__"],
+)
+
+# Build a persistent Ubuntu base image with tools needed by integration tests.
+# It boots once with internet access and installs iputils-ping into the base image.
+genrule(
+    name = "prepared_image",
+    srcs = ["@ubuntu_24_04_cloudimg//file"],
+    outs = ["ubuntu24_04_prepared.qcow2"],
+    cmd = "bash $(location prepare_image.sh) $(location @ubuntu_24_04_cloudimg//file) $@",
+    tags = [
+        "manual",
+        "requires-network",
+    ],
+    tools = ["prepare_image.sh"],
     visibility = ["//:__subpackages__"],
 )

--- a/quality/integration_testing/environments/ubuntu24_04_qemu/prepare_image.sh
+++ b/quality/integration_testing/environments/ubuntu24_04_qemu/prepare_image.sh
@@ -33,9 +33,24 @@ chmod u+w "${output_image}"
 
 cat >"${tmp_dir}/user-data" <<'EOF'
 #cloud-config
+# Prepare base image: minimize boot overhead by disabling non-essential packages and services.
+
 package_update: true
 packages:
   - iputils-ping
+
+# Remove unnecessary packages to reduce image size and boot time
+bootcmd:
+  # Disable non-essential services - be conservative to avoid breaking system
+  # Disable update services (not needed for test environment)
+  - systemctl mask apt-daily.timer apt-daily-upgrade.timer unattended-upgrades
+  # Disable hardware-specific services not needed for QEMU
+  - systemctl mask accounts-daemon multipathd e2scrub.timer e2scrub_all.timer
+  # Disable bluetooth, printing, and mDNS services
+  - systemctl mask bluetooth cups cups-browsed avahi-daemon
+  # Disable unnecessary timer jobs
+  - systemctl mask motd-news.timer
+
 power_state:
   mode: poweroff
   timeout: 120

--- a/quality/integration_testing/environments/ubuntu24_04_qemu/prepare_image.sh
+++ b/quality/integration_testing/environments/ubuntu24_04_qemu/prepare_image.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <base-image> <output-image>" >&2
+    exit 1
+fi
+
+base_image="$1"
+output_image="$2"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+cp --reflink=auto "${base_image}" "${output_image}"
+chmod u+w "${output_image}"
+
+cat >"${tmp_dir}/user-data" <<'EOF'
+#cloud-config
+package_update: true
+packages:
+  - iputils-ping
+power_state:
+  mode: poweroff
+  timeout: 120
+EOF
+
+cat >"${tmp_dir}/meta-data" <<'EOF'
+instance-id: ubuntu24-prepare-image
+local-hostname: ubuntu24-prepare-image
+EOF
+
+cloud-localds "${tmp_dir}/seed.img" "${tmp_dir}/user-data" "${tmp_dir}/meta-data"
+
+# Boot once with user-mode networking (NAT) to provide internet access for apt.
+# Cloud-init installs iputils-ping and powers the VM off when complete.
+timeout 25m qemu-system-x86_64 \
+    -machine accel=kvm:tcg \
+    -cpu max \
+    -smp 2 \
+    -m 2048 \
+    -drive if=virtio,format=qcow2,file="${output_image}" \
+    -drive if=virtio,format=raw,file="${tmp_dir}/seed.img" \
+    -nic user,model=virtio-net-pci \
+    -nographic \
+    -display none \
+    -serial none \
+    -monitor none \
+    -no-reboot
+
+qemu-img info "${output_image}" >/dev/null

--- a/quality/integration_testing/environments/ubuntu24_04_qemu/user-data
+++ b/quality/integration_testing/environments/ubuntu24_04_qemu/user-data
@@ -2,6 +2,7 @@
 # Cloud-init configuration for QEMU-based integration tests.
 # Enables root SSH access with empty password for the ITF test harness.
 # All config is in bootcmd to ensure it runs before sshd starts.
+# Services are already masked from image prep; this ensures minimal runtime overhead.
 
 ssh_pwauth: true
 disable_root: false
@@ -11,7 +12,3 @@ bootcmd:
   - printf 'PermitRootLogin yes\nPermitEmptyPasswords yes\nPasswordAuthentication yes\n' > /etc/ssh/sshd_config.d/99-integration-test.conf
   - printf 'auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession sufficient pam_permit.so\n' > /etc/pam.d/sshd
   - iface=$(ip -4 route show default | awk '{print $5; exit}'); [ -n "$iface" ] && ip route replace 224.0.0.0/4 dev "$iface"
-
-# runcmd:
-#   - systemctl enable ssh
-#   - systemctl restart ssh

--- a/quality/integration_testing/environments/ubuntu24_04_qemu/user-data
+++ b/quality/integration_testing/environments/ubuntu24_04_qemu/user-data
@@ -10,7 +10,7 @@ bootcmd:
   - sed -i 's/^root:[^:]*:/root::/' /etc/shadow
   - printf 'PermitRootLogin yes\nPermitEmptyPasswords yes\nPasswordAuthentication yes\n' > /etc/ssh/sshd_config.d/99-integration-test.conf
   - printf 'auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession sufficient pam_permit.so\n' > /etc/pam.d/sshd
-  - ip route add 224.0.0.0/4 dev ens4
+  - iface=$(ip -4 route show default | awk '{print $5; exit}'); [ -n "$iface" ] && ip route replace 224.0.0.0/4 dev "$iface"
 
 # runcmd:
 #   - systemctl enable ssh

--- a/quality/integration_testing/integration_testing.bzl
+++ b/quality/integration_testing/integration_testing.bzl
@@ -57,7 +57,7 @@ def integration_test(name, srcs, filesystem, **kwargs):
     )
 
     linux_qemu_config = Label("//quality/integration_testing/environments/ubuntu24_04_qemu:qemu_config")
-    linux_qemu_image = Label("@ubuntu_24_04_cloudimg//file")
+    linux_qemu_image = Label("//quality/integration_testing/environments/ubuntu24_04_qemu:prepared_image")
     linux_qemu_seed_iso = Label("//quality/integration_testing/environments/ubuntu24_04_qemu:seed_iso")
 
     # --- QNX QEMU artifacts ---


### PR DESCRIPTION
The full Ubuntu server image is big and starts more services, which increases its boot time. With the minimal image the boot time was reduced by ~5s - 10s. It is still too much for my taste, but an easy gain.