### PR TITLE
fix: Limit symbol export of null_serializer

### DIFF
--- a/src/serializer/BUILD.bazel
+++ b/src/serializer/BUILD.bazel
@@ -56,7 +56,9 @@ cc_test(
 # Serializer that can only handle pre-serialized data and is used as default serializer for gatewayd if no other serializer is provided.
 cc_shared_library(
     name = "null_serializer",
+    additional_linker_inputs = ["exported_symbols.lds"],
     shared_lib_name = "score_com_serializer.so",
+    user_link_flags = ["-Wl,--version-script=$(location exported_symbols.lds)"],
     visibility = ["//visibility:public"],
     deps = [":null_serializer_impl"],
 )

--- a/src/serializer/exported_symbols.lds
+++ b/src/serializer/exported_symbols.lds
@@ -1,0 +1,19 @@
+/* *******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * ******************************************************************************* */
+
+ {
+  global:
+    score_com_serializer_*;
+  local:
+    *;
+};


### PR DESCRIPTION
Introduce a linker version script for the "null_serializer" to only export the symbols of the serializer API. 

Without it the shared library score_com_serializer.so exported all symbols from its transitive deps (including `score::mw::log`, `score::os`, `score::json`, `score::cpp::pmr`). When the linker resolved gatewayd against this shared library (via cc_import's interface_library), it bound those symbols dynamically instead of pulling them from the static libraries. Using another serializer .so (via this plugin mechanism) that doesn't contain those same symbols leads to unresolved symbols during runtime.