### PR TITLE
ci: Make QNX job required

### DIFF
--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -55,8 +55,7 @@ jobs:
     name: ci_pull_request_target/can_merge
     if: always()
     needs:
-      # No need to pass as long as SDK download is unstable
-      # - build_and_test_qnx
+      - build_and_test_qnx
       - docs
       - license_check
     permissions:


### PR DESCRIPTION
It has been optional due to issues downloading the QNX SDK. Now the Github Caching logic has been improved and seems to reliably cache the QNX SDK. On the other hand we had multiple pull requests breaking QNX. This should better ensure that QNX stays working.