### PR TITLE
ci: Update and pin caching workflows and actions

### DIFF
--- a/.github/workflows/build_and_test_cross_compilation.yml
+++ b/.github/workflows/build_and_test_cross_compilation.yml
@@ -24,8 +24,6 @@ jobs:
       matrix:
         bazel-config: ["x86_64-linux", "aarch64-linux"]
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
     steps:
       - uses: eclipse-score/more-disk-space@v1
       - name: Checkout repository
@@ -37,7 +35,7 @@ jobs:
       - name: Create config indicator file
         run: echo "${{ matrix.bazel-config }}" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}-${{ matrix.bazel-config }}
       - name: Allow linux-sandbox

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -20,8 +20,6 @@ on:
 jobs:
   build_and_test_host:
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
     steps:
       - uses: eclipse-score/more-disk-space@v1
       - name: Checkout repository
@@ -33,7 +31,7 @@ jobs:
       - name: Create config indicator file
         run: echo "host" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
       - name: Allow linux-sandbox
@@ -52,8 +50,6 @@ jobs:
 
   build_and_int_qemu_test_host:
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
     steps:
       - uses: eclipse-score/more-disk-space@v1
       - name: Checkout repository
@@ -65,7 +61,7 @@ jobs:
       - name: Create config indicator file
         run: echo "host" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
       - name: Install tools needed for ITF tests

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,11 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@improved-caching-part-2
     permissions:
       contents: read
       pull-requests: read
-      actions: write # needed for cache deletion at setup-bazel-cache
     with:
       # TODO: build all targets ( //... ) once python toolchain issue is resolved.
       bazel-target: "//src/... //tests/... //examples/..."

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -27,7 +27,7 @@ jobs:
       score-qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
       score-qnx-user: ${{ secrets.SCORE_QNX_USER }}
       score-qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
-    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     with:
       variants: |
         //...

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -48,7 +48,6 @@ jobs:
     needs:
       - repository_cache_maintenance
     permissions:
-      actions: read
       contents: write
       pages: write
       pull-requests: write

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -21,28 +21,25 @@ on:
 jobs:
   repository_cache_maintenance:
     permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
+      actions: write # needed for cache deletion after cache refresh
       contents: read
     secrets:
       score-qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
       score-qnx-user: ${{ secrets.SCORE_QNX_USER }}
       score-qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
-    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@improved-caching-part-2
     with:
       variants: |
-        |//...
-        qemu-integration|//quality/... //tests/...
-        x86_64-linux|//...
-        aarch64-linux|//...
-        x86_64-qnx|//quality/... //src/... //tests/...
-        aarch64-qnx|//quality/... //src/... //tests/...
+        //...
+        --config=qemu-integration //quality/... //tests/...
+        --config=x86_64-linux //...
+        --config=aarch64-linux //...
+        --config=x86_64-qnx //quality/... //src/... //tests/...
+        --config=aarch64-qnx //quality/... //src/... //tests/...
 
   ci:
     needs:
       - repository_cache_maintenance
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
-      contents: read
     secrets: inherit
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/ci.yml
@@ -51,7 +48,7 @@ jobs:
     needs:
       - repository_cache_maintenance
     permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
+      actions: read
       contents: write
       pages: write
       pull-requests: write
@@ -60,3 +57,16 @@ jobs:
     secrets: inherit
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/ci_pull_request_target.yml
+
+  delete_old_caches:
+    runs-on: ubuntu-24.04
+    needs:
+      - ci
+      - ci_pull_request_target
+    permissions:
+      actions: write # needed for deletion of old caches
+      contents: read
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Prune obsolete Bazel caches
+        uses: eclipse-score/cicd-actions/prune-cache@8e69f47b45778afd3b0d069c0456184c4ceeffe7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,28 +24,18 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/pre-commit.yml
   build_and_test_host:
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
     secrets: inherit
     uses: ./.github/workflows/build_and_test_host.yml
   build_and_test_cross_compilation:
     # Do not run by default for every PR.
     # Run either in merge queue or if the pull request has the 'test-cross' label.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-cross')
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
     secrets: inherit
     uses: ./.github/workflows/build_and_test_cross_compilation.yml
   copyright:
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
-      contents: read
     secrets: inherit
     uses: ./.github/workflows/copyright.yml
   format:
-    permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
-      contents: read
     secrets: inherit
     uses: ./.github/workflows/format.yml
   # check if PR can be enqueued to the merge queue or merged to main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,14 @@ jobs:
       - build_and_test_cross_compilation
       - copyright
       - format
-    permissions:
-      actions: read
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - env:
-          NEEDS_JSON: "${{toJSON(needs)}}"
-        name: Transform outcomes
+      - name: Fail if any required job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
-          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >>$GITHUB_ENV
-      - name: check
-        run: |
-          [ $ALL_SUCCESS == true ]
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
   # workaround to get running merge queue checks visible in the PR checks list, as GitHub does not show merge group check runs in the UI.
   can_see_status:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -27,14 +27,12 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/build_and_test_qnx.yml
     permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
       contents: read
       pull-requests: read
   docs:
     secrets: inherit
     uses: ./.github/workflows/docs.yml
     permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
       contents: write
       pages: write
       pull-requests: write
@@ -43,7 +41,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/license_check.yml
     permissions:
-      actions: write # needed for cache deletion at setup-bazel-cache
       pull-requests: write
       issues: write
   # check if PR can be enqueued to the merge queue or merged to main

--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -55,18 +55,14 @@ jobs:
       - build_and_test_qnx
       - docs
       - license_check
-    permissions:
-      actions: read
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - env:
-          NEEDS_JSON: "${{toJSON(needs)}}"
-        name: Transform outcomes
+      - name: Fail if any required job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
-          echo "ALL_SUCCESS=$(echo "$NEEDS_JSON" | jq '. | to_entries | map([.value.result == "success", .value.result == "skipped"] | any) | all')" >>$GITHUB_ENV
-      - name: check
-        run: |
-          [ $ALL_SUCCESS == true ]
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
   # workaround to get running merge queue checks visible in the PR checks list, as GitHub does not show merge group check runs in the UI.
   can_see_status:
     runs-on: ubuntu-latest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,6 @@ jobs:
       # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission.
       # If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
       contents: read
-      actions: write # needed for cache deletion at setup-bazel-cache
 
     steps:
       - uses: eclipse-score/more-disk-space@v1
@@ -43,7 +42,7 @@ jobs:
           sudo mkdir -p /mnt/.bazel
           sudo chown -R $USER:$USER /mnt/.bazel
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@use-lurtz-setup-bazel
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
         with:
           unique-cache-name: ${{ github.job }}
       - name: Allow linux-sandbox

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -17,9 +17,8 @@ on:
 
 permissions:
   contents: read
-  actions: write # needed for cache deletion at setup-bazel-cache
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@improved-caching-part-2
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -19,6 +19,6 @@ permissions:
   contents: read
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@improved-caching-part-2
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,20 +18,18 @@ permissions:
   pages: write
   pull-requests: write
   id-token: write
-  actions: write # needed for cache deletion at setup-bazel-cache
 
 on:
   workflow_call:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@improved-caching-part-2
     permissions:
       contents: write
       pages: write
       pull-requests: write
       id-token: write
-      actions: write # needed for cache deletion at setup-bazel-cache
 
     with:
       # the bazel-target depends on your repo specific docs_targets configuration (e.g. "suffix")

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,6 @@ permissions:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,10 +18,9 @@ on:
 
 permissions:
   contents: read
-  actions: write # needed for cache deletion at setup-bazel-cache
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@improved-caching-part-2
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -22,6 +22,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@improved-caching-part-2
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -19,10 +19,9 @@ on:
 permissions:
   pull-requests: write
   issues: write
-  actions: write # needed for cache deletion at setup-bazel-cache
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@improved-caching
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@improved-caching-part-2
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
Using branches was only done to enable a quicker debug and test cycle. Now the logic is improved and settled and we can pin versions again.

The bigger picture is explained there: https://github.com/eclipse-score/cicd-workflows/blob/main/.github/workflows/cache-maintenance.yml