### PR TITLE
ci: Run cache maintenance check in merge queue

### DIFF
--- a/.github/workflows/build_and_test_cross_compilation.yml
+++ b/.github/workflows/build_and_test_cross_compilation.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Create config indicator file
         run: echo "${{ matrix.bazel-config }}" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}-${{ matrix.bazel-config }}
       - name: Allow linux-sandbox
-        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@659dcbed63f6b7fbde88c7850125ea0a0a92f939
+        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
       - run: df -h
       - name: Bazel build targets
         # TODO: build all targets ( //... ) once python toolchain issue is resolved.

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Create config indicator file
         run: echo "host" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
       - name: Allow linux-sandbox
-        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@659dcbed63f6b7fbde88c7850125ea0a0a92f939
+        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
       - run: df -h
       - name: Bazel build targets
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Create config indicator file
         run: echo "host" > .bazel_config
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
       - name: Install tools needed for ITF tests
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 iputils-ping tcpdump cloud-image-utils
       - name: Allow linux-sandbox
-        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@659dcbed63f6b7fbde88c7850125ea0a0a92f939
+        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
       - run: df -h
       - name: Enable KVM group permissons
         run: |

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -13,7 +13,15 @@
 
 name: Cache maintenance
 
+# Refreshes caches and rebuilds a new bazel repository cache when MODULE.bazel.lock changes.
+# Caches are only saved on pushes to the main branch or on workflow_dispatch events.
+# In merge_groups and pull requests a fast dry-run is executed to ensure inputs are valid and caches can be rebuilt successfully.
+
 on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
   push:
     branches: [main]
@@ -27,7 +35,7 @@ jobs:
       score-qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
       score-qnx-user: ${{ secrets.SCORE_QNX_USER }}
       score-qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
-    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@make-cache-maintenance-executable-in-merge-queue
     with:
       variants: |
         //...
@@ -41,7 +49,7 @@ jobs:
     needs:
       - repository_cache_maintenance
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/ci.yml
 
   ci_pull_request_target:
@@ -54,7 +62,7 @@ jobs:
       id-token: write
       issues: write
     secrets: inherit
-    if: ${{ !cancelled() }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/ci_pull_request_target.yml
 
   delete_old_caches:
@@ -65,7 +73,7 @@ jobs:
     permissions:
       actions: write # needed for deletion of old caches
       contents: read
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name == 'push' }}
     steps:
       - name: Prune obsolete Bazel caches
         uses: eclipse-score/cicd-actions/prune-cache@af1be61755b13c1f33b6c250080dc6ac025012f1

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -35,7 +35,7 @@ jobs:
       score-qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
       score-qnx-user: ${{ secrets.SCORE_QNX_USER }}
       score-qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
-    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@make-cache-maintenance-executable-in-merge-queue
+    uses: eclipse-score/cicd-workflows/.github/workflows/cache-maintenance.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     with:
       variants: |
         //...

--- a/.github/workflows/cache_maintenance.yml
+++ b/.github/workflows/cache_maintenance.yml
@@ -76,4 +76,4 @@ jobs:
     if: ${{ !cancelled() && github.event_name == 'push' }}
     steps:
       - name: Prune obsolete Bazel caches
-        uses: eclipse-score/cicd-actions/prune-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/prune-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,8 +42,8 @@ jobs:
           sudo mkdir -p /mnt/.bazel
           sudo chown -R $USER:$USER /mnt/.bazel
       - name: Setup Bazel
-        uses: eclipse-score/cicd-actions/setup-bazel-cache@af1be61755b13c1f33b6c250080dc6ac025012f1
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@07cd8ac969b01fbab47f1a0b91040bcd83008fa7
         with:
           unique-cache-name: ${{ github.job }}
       - name: Allow linux-sandbox
-        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@659dcbed63f6b7fbde88c7850125ea0a0a92f939
+        uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@07cd8ac969b01fbab47f1a0b91040bcd83008fa7

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -19,6 +19,6 @@ permissions:
   contents: read
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,6 @@ permissions:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -22,6 +22,6 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@0bd0be843039a465d2f485607a31e8df4268efa0
     secrets:
       dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
So far changes to cache maintenance will only start to fail after a pull request has been merged to main. This is too late and should be discovered beforehand. The current solution is not 100% waterproof, but should catch most errors. A waterproof solution using `bazel cquery` consumes too much CI time.

Depends on:
- https://github.com/eclipse-score/cicd-workflows/pull/141
- https://github.com/eclipse-score/cicd-actions/pull/17

This is an alternative to #195. This one has the downside that a pull request to https://github.com/eclipse-score/.eclipsefdn will be needed later to enforce cache input validation. But I consider this the lesser evil compared to an almost circular dependency chain as seen in #195.