### PR TITLE
Move qnx job to pull request

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: ["x86_64-qnx", "aarch64-qnx"]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@4ce43f957a0e164827ad2906a2ec69fd7f420b5d
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@bump-checkout-action
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-cross')
     secrets: inherit
     uses: ./.github/workflows/build_and_test_cross_compilation.yml
+  build_and_test_qnx:
+    # Do not run by default for every PR.
+    # Run either in merge queue or if the pull request has the 'test-qnx' label.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-qnx')
+    secrets: inherit
+    uses: ./.github/workflows/build_and_test_qnx.yml
+    permissions:
+      contents: read
+      pull-requests: read
   copyright:
     secrets: inherit
     uses: ./.github/workflows/copyright.yml
@@ -50,6 +59,7 @@ jobs:
       - pre-commit
       - build_and_test_host
       - build_and_test_cross_compilation
+      - build_and_test_qnx
       - copyright
       - format
     permissions: {}

--- a/.github/workflows/ci_pull_request_target.yml
+++ b/.github/workflows/ci_pull_request_target.yml
@@ -20,15 +20,6 @@ on:
   workflow_dispatch:
   workflow_call:
 jobs:
-  build_and_test_qnx:
-    # Do not run by default for every PR.
-    # Run either in merge queue or if the pull request has the 'test-qnx' label.
-    if: github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'test-qnx')
-    secrets: inherit
-    uses: ./.github/workflows/build_and_test_qnx.yml
-    permissions:
-      contents: read
-      pull-requests: read
   docs:
     secrets: inherit
     uses: ./.github/workflows/docs.yml
@@ -52,7 +43,6 @@ jobs:
     name: ci_pull_request_target/can_merge
     if: always()
     needs:
-      - build_and_test_qnx
       - docs
       - license_check
     permissions: {}


### PR DESCRIPTION
pull_request_target triggers need to be retired and this is a preparation step