### PR TITLE
fix: ipc binding test teardown race in coverage builds

### DIFF
--- a/score/gateway_ipc_binding/test/client_server_test.cpp
+++ b/score/gateway_ipc_binding/test/client_server_test.cpp
@@ -38,6 +38,7 @@
 #include "util.hpp"
 
 using testing::_;
+using testing::AnyNumber;
 using testing::AtMost;
 using testing::Return;
 using testing::Values;
@@ -219,8 +220,8 @@ class Gateway_ipc_binding_test : public Gateway_ipc_binding_unconnected_test {
                 event_subscription_change_promise.set_value();
             });
 
-        // EXPECT_CALL(mock_event_subscription_change_cb,
-        //             Call(_, event_id, socom::Event_state::unsubscribed));
+        EXPECT_CALL(mock_event_subscription_change_cb,
+                    Call(_, event_id, socom::Event_state::unsubscribed)).Times(AnyNumber());
 
         auto const subscribe_result =
             client_connector.subscribe_event(event_id, score::socom::Event_mode::update);


### PR DESCRIPTION
`gateway_ipc_binding_test` fails under coverage/ferrocene instrumentation.

The test expects a mock callback to be called once with `subscribed`. After that, the same mock receives an `unsubscribed` callback during test teardown, which the test does not expect. Under normal builds, teardown is fast and the callback arrives after the mock is gone. Under instrumented builds, teardown is slower and the callback arrives while the mock is still active, causing the test to fail.

Fix: add `Times(AnyNumber())` to the `unsubscribed` `EXPECT_CALL` in `subscribe_event()` so the mock accepts that callback during teardown.