### PR TITLE
chore(devcontainer): align SCORE devcontainer versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.9.0
+FROM ghcr.io/eclipse-score/devcontainer:v1.10.0
 
 # Build argument for dynamic username (defaults to 'vscode' if not provided)
 ARG USERNAME=vscode

--- a/.devcontainer/run_tool.sh
+++ b/.devcontainer/run_tool.sh
@@ -14,14 +14,11 @@
 # *******************************************************************************
 
 # Unified entry point for running a CLI tool by name.
-
 # Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
 # See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
-
-# Why? Because bazel gives us the ability to run tools without installing them or requiring users
-# to run inside a devcontainer. However bazel is crazy slow and not really suited to be run from
-# pre-commit, so we need a shortcut to keep it fast for users who are already inside a
-# devcontainer.
+#
+# Do not modify this file. Its source of truth is managed by the
+# SCORE devcontainer version-alignment policy.
 
 set -euo pipefail
 


### PR DESCRIPTION
<!-- repo-sync-policy: devcontainer.score-version-alignment -->
<!-- repo-sync-head: 26da7b07d32fa9c73de2cbea803e4a86a372452c -->

## Policy

**`devcontainer.score-version-alignment`**

Keep the SCORE devcontainer image and direct score_devcontainer dependency on
the same version by upgrading only the older declaration.


## Why this repository?

This repository matches this policy because `.devcontainer/Dockerfile` matches this policy's file-content condition and `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_devcontainer`.

## Changes

- `.devcontainer/run_tool.sh`: synchronize contents
  - Provide the standard SCORE tool launcher in repositories using the SCORE devcontainer.
- `.devcontainer/Dockerfile`: align version from '1.9.0' to '1.10.0'
  - Keep the development image and its Bazel integration on a compatible version.



---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!WARNING]
> The tool producing this PR is in proof-of-concept stage. Review carefully.
