### PR TITLE
chore(devcontainer): standardize SCORE devcontainer integration

### DIFF
--- a/.devcontainer/run-tool
+++ b/.devcontainer/run-tool
@@ -18,7 +18,7 @@
 # See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
 #
 # Do not modify this file. Its source of truth is managed by the
-# SCORE devcontainer version-alignment policy.
+# SCORE devcontainer standardization policy.
 
 set -euo pipefail
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,11 @@ repos:
         name: shellcheck
         # Hint: running this avoids users having to run inside the devcontainer,
         # while pinning the version of shellcheck to the one in the devcontainer.
-        entry: .devcontainer/run_tool.sh shellcheck
+        entry: .devcontainer/run-tool shellcheck
         language: system
         types: [shell]
       - id: yamlfmt
         name: yamlfmt
-        entry: .devcontainer/run_tool.sh yamlfmt
+        entry: .devcontainer/run-tool yamlfmt
         language: system
         types: [yaml]


### PR DESCRIPTION
<!-- repo-policy-sync-policy: devcontainer.score-standardization -->
<!-- repo-policy-sync-head: 5913f8a10eada7209e477904b76a97dac4923886 -->

## Policy

**`devcontainer.score-standardization`**

Keep the SCORE devcontainer image and direct dependency on the same version,
and provide the standard SCORE tool launcher.


## Why this repository?

This repository matches this policy because `.devcontainer/Dockerfile` matches this policy's file-content condition and `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_devcontainer`.

## Changes

- `.devcontainer/run-tool`: add file
  - Provide the standard SCORE tool launcher in repositories using the SCORE devcontainer.
- `.pre-commit-config.yaml`: replace matching text
  - Point pre-commit hooks at the standard SCORE tool launcher.
- `.devcontainer/run_tool.sh`: remove file
  - Replace the previous launcher path with the standard hyphenated path.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.
