### PR TITLE
feat(tc8): add ETS stub DUT and someipd logging migration

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -50,13 +50,9 @@ path = [
     "tests/integration_test/vsomeip-local.json",
     "tests/integration_test/vsomeip.json",
     "tests/benchmarks/config/benchmark_mw_com_config.json",
+    "tests/tc8_conformance/**/*.json",
     "quality/integration_testing/environments/qnx8_qemu/qemu_config.json",
     "quality/integration_testing/environments/ubuntu24_04_qemu/*"
 ]
-SPDX-FileCopyrightText = "Copyright (c) 2026 Contributors to the Eclipse Foundation"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = ["tests/tc8_conformance/config/*.json"]
 SPDX-FileCopyrightText = "Copyright (c) 2026 Contributors to the Eclipse Foundation"
 SPDX-License-Identifier = "Apache-2.0"

--- a/score/someipd/main.cpp
+++ b/score/someipd/main.cpp
@@ -14,13 +14,11 @@
 #include <getopt.h>
 
 #include <atomic>
-#include <chrono>
 #include <csignal>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <thread>
 
 #include "local_network_service.h"
 #include "remote_network_service.h"
@@ -40,9 +38,8 @@ using namespace score::someipd;
 // Global flag to control application shutdown
 static std::atomic<bool> shutdown_requested{false};
 
-// Signal handler for graceful shutdown
 void termination_handler(int /*signal*/) {
-    std::cout << "Received termination signal. Initiating graceful shutdown..." << std::endl;
+    score::mw::log::LogWarn() << "Received termination signal. Initiating graceful shutdown...";
     shutdown_requested.store(true);
 }
 
@@ -148,7 +145,7 @@ int main(int argc, char* argv[]) {
         score::mw::log::LogFatal() << "[someipd] Failed to start IPC server";
         return 1;
     }
-    std::cout << "[someipd] IPC server started, waiting for gatewayd connection..." << std::endl;
+    score::mw::log::LogInfo() << "[someipd] IPC server started, waiting for gatewayd connection...";
 
     auto routing = Routing::Create(config);
     if (!routing.has_value()) {
@@ -165,11 +162,12 @@ int main(int argc, char* argv[]) {
             continue;
         }
         for (auto const& service_instance_config : *service_instances) {
-            std::cout << "[someipd] Creating LocalNetworkService: "
-                      << service_type_config->service_type_name()->string_view()
-                      << " (service_id=0x" << std::hex << service_type_config->service_id()
-                      << std::dec << ", instance_id=0x" << std::hex
-                      << service_instance_config->instance_id() << std::dec << ")" << std::endl;
+            score::mw::log::LogInfo()
+                << "[someipd] Creating LocalNetworkService: "
+                << service_type_config->service_type_name()->string_view()
+                << " service_id=0x" << score::mw::log::LogHex16{service_type_config->service_id()}
+                << " instance_id=0x"
+                << score::mw::log::LogHex16{service_instance_config->instance_id()};
             auto create_result = LocalNetworkService::Create(
                 std::shared_ptr<const score::mw_someip_config::ServiceInstance>(
                     config, service_instance_config),
@@ -196,11 +194,12 @@ int main(int argc, char* argv[]) {
             continue;
         }
         for (auto const& service_instance_config : *service_instances) {
-            std::cout << "[someipd] Creating RemoteNetworkService: "
-                      << service_type_config->service_type_name()->string_view()
-                      << " (service_id=0x" << std::hex << service_type_config->service_id()
-                      << std::dec << ", instance_id=0x" << std::hex
-                      << service_instance_config->instance_id() << std::dec << ")" << std::endl;
+            score::mw::log::LogInfo()
+                << "[someipd] Creating RemoteNetworkService: "
+                << service_type_config->service_type_name()->string_view()
+                << " service_id=0x" << score::mw::log::LogHex16{service_type_config->service_id()}
+                << " instance_id=0x"
+                << score::mw::log::LogHex16{service_instance_config->instance_id()};
             auto create_result = RemoteNetworkService::Create(
                 std::shared_ptr<const score::mw_someip_config::ServiceInstance>(
                     config, service_instance_config),
@@ -217,13 +216,13 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    std::cout << "[someipd] Starting routing loop..." << std::endl;
+    score::mw::log::LogInfo() << "[someipd] Starting routing loop...";
     routing.value().Run(shutdown_requested, [&remote_network_services]() {
         for (auto& svc : remote_network_services) {
             svc->setup_vsomeip();
         }
     });
 
-    std::cout << "[someipd] Shutting down SOME/IP daemon..." << std::endl;
+    score::mw::log::LogInfo() << "[someipd] Shutting down SOME/IP daemon...";
     return EXIT_SUCCESS;
 }

--- a/tests/tc8_conformance/application/README.md
+++ b/tests/tc8_conformance/application/README.md
@@ -27,5 +27,4 @@ application/
 
 ## See Also
 
-- [Architecture](../../../docs/architecture/tc8_conformance_testing.rst)
 - Protocol conformance tests in the parent directory [`tests/tc8_conformance/`](../)

--- a/tests/tc8_conformance/application/README.md
+++ b/tests/tc8_conformance/application/README.md
@@ -28,4 +28,4 @@ application/
 ## See Also
 
 - [Architecture](../../../docs/architecture/tc8_conformance_testing.rst)
-- Protocol conformance tests in the parent directory (`tests/tc8_conformance/`)
+- Protocol conformance tests in the parent directory [`tests/tc8_conformance/`](../)

--- a/tests/tc8_conformance/application/README.md
+++ b/tests/tc8_conformance/application/README.md
@@ -1,0 +1,31 @@
+<!-- ----------------------------------------------------------------------------
+  Copyright (c) 2026 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  SPDX-License-Identifier: Apache-2.0
+----------------------------------------------------------------------------- -->
+
+# TC8 Conformance — Application Components
+
+C++ applications used by the TC8 conformance test suite.
+
+## Structure
+
+```
+application/
+├── shared/          # Shared header: tc8_ets_service constants and event descriptors
+└── ets_stub/        # ETS stub binary: offers tc8_service via mw::com skeleton,
+                     #   sends periodic event notifications for TC8 test capture
+    └── config/      # mw::com manifest (tc8_ets_stub_mw_com_config.json)
+```
+
+## See Also
+
+- [Architecture](../../../docs/architecture/tc8_conformance_testing.rst)
+- Protocol conformance tests in the parent directory (`tests/tc8_conformance/`)

--- a/tests/tc8_conformance/application/ets_stub/BUILD.bazel
+++ b/tests/tc8_conformance/application/ets_stub/BUILD.bazel
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
+exports_files(
+    ["config/tc8_ets_stub_mw_com_config.json"],
+    visibility = ["//tests/tc8_conformance:__pkg__"],
+)
+
+cc_binary(
+    name = "tc8_ets_stub",
+    srcs = ["tc8_ets_stub.cpp"],
+    visibility = ["//tests/tc8_conformance:__pkg__"],
+    deps = [
+        "//score/serializer:pre_serialized_data",
+        "//tests/tc8_conformance/application/shared:tc8_ets_service",
+        "@score_baselibs//score/filesystem",
+        "@score_baselibs//score/mw/log",
+        "@score_communication//score/mw/com",
+    ],
+)

--- a/tests/tc8_conformance/application/ets_stub/config/tc8_ets_stub_mw_com_config.json
+++ b/tests/tc8_conformance/application/ets_stub/config/tc8_ets_stub_mw_com_config.json
@@ -1,0 +1,122 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "tc8_service",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 4660,
+          "events": [
+            {
+              "eventName": "TestEventUINT8",
+              "eventId": 1
+            },
+            {
+              "eventName": "TestEventUINT8Array",
+              "eventId": 2
+            },
+            {
+              "eventName": "TestEventUINT8Reliable",
+              "eventId": 3
+            },
+            {
+              "eventName": "TestEventUINT8E2E",
+              "eventId": 4
+            },
+            {
+              "eventName": "InterfaceVersion",
+              "eventId": 5
+            },
+            {
+              "eventName": "TestFieldUINT8",
+              "eventId": 6
+            },
+            {
+              "eventName": "TestFieldUINT8Array",
+              "eventId": 7
+            },
+            {
+              "eventName": "TestFieldUINT8Reliable",
+              "eventId": 8
+            },
+            {
+              "eventName": "TestEventUINT8Multicast",
+              "eventId": 9
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "tc8/tc8_service",
+      "serviceTypeName": "tc8_service",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 22136,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "TestEventUINT8",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestEventUINT8Array",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestEventUINT8Reliable",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestEventUINT8E2E",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "InterfaceVersion",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestFieldUINT8",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestFieldUINT8Array",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestFieldUINT8Reliable",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            },
+            {
+              "eventName": "TestEventUINT8Multicast",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "QM"
+  }
+}

--- a/tests/tc8_conformance/application/ets_stub/tc8_ets_stub.cpp
+++ b/tests/tc8_conformance/application/ets_stub/tc8_ets_stub.cpp
@@ -1,0 +1,115 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstddef>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include "score/filesystem/path.h"
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/runtime_configuration.h"
+#include "score/mw/com/types.h"
+#include "score/mw/log/logging.h"
+#include "score/serializer/pre_serialized_data.h"
+#include "tests/tc8_conformance/application/shared/tc8_ets_service.h"
+
+namespace {
+using Payload = score::someip_gateway::serializer::PreSerializedData<tc8_ets_service::kMaxPayloadBytes>;
+}  // namespace
+
+constexpr std::string_view kInstanceSpecifier{"tc8/tc8_service"};
+
+static std::atomic<bool> g_shutdown_requested{false};
+
+static void SignalHandler(int /*signal*/) {
+    g_shutdown_requested.store(true);
+}
+
+int main(int argc, char* argv[]) {
+    std::signal(SIGTERM, SignalHandler);
+    std::signal(SIGINT, SignalHandler);
+
+    std::string manifest_path;
+    for (int i = 1; i < argc; ++i) {
+        if ((std::strcmp(argv[i], "-s") == 0) && (i + 1 < argc)) {
+            manifest_path = argv[++i];
+        }
+    }
+    if (manifest_path.empty()) {
+        score::mw::log::LogError() << "[tc8_ets_stub] Usage: tc8_ets_stub -s <mw_com_config.json>";
+        return 1;
+    }
+
+    score::mw::com::runtime::InitializeRuntime(score::mw::com::runtime::RuntimeConfiguration{
+        score::filesystem::Path{manifest_path}});
+
+    const auto specifier_result = score::mw::com::InstanceSpecifier::Create(std::string{kInstanceSpecifier});
+    if (!specifier_result.has_value()) {
+        score::mw::log::LogError() << "[tc8_ets_stub] Failed to create InstanceSpecifier for tc8/tc8_service";
+        return 1;
+    }
+
+    score::mw::com::GenericSkeletonServiceElementInfo create_params;
+    create_params.events = tc8_ets_service::kEvents;
+
+    auto skeleton_result =
+        score::mw::com::GenericSkeleton::Create(specifier_result.value(), create_params);
+    if (!skeleton_result.has_value()) {
+        score::mw::log::LogError() << "[tc8_ets_stub] GenericSkeleton::Create failed for tc8/tc8_service";
+        return 1;
+    }
+    auto& skeleton = skeleton_result.value();
+
+    const auto offer_result = skeleton.OfferService();
+    if (!offer_result.has_value()) {
+        score::mw::log::LogError() << "[tc8_ets_stub] OfferService() failed";
+        return 1;
+    }
+    score::mw::log::LogInfo() << "[tc8_ets_stub] tc8_service offered, sending periodic notifications";
+
+    auto events_view = skeleton.GetEvents();
+    auto last_notify_time = std::chrono::steady_clock::now();
+
+    while (!g_shutdown_requested.load()) {
+        auto now = std::chrono::steady_clock::now();
+        if (now - last_notify_time >= std::chrono::milliseconds(500)) {
+            last_notify_time = now;
+            for (const score::mw::com::EventInfo& ev_info : tc8_ets_service::kEvents) {
+                auto it = events_view.find(ev_info.name);
+                if (it == events_view.cend()) {
+                    continue;
+                }
+                score::mw::com::GenericSkeletonEvent& event = it->second;
+                auto alloc_result = event.Allocate();
+                if (!alloc_result.has_value()) {
+                    continue;
+                }
+                auto sample = std::move(alloc_result).value();
+                auto* pre_data = static_cast<Payload*>(sample.Get());
+                pre_data->size = tc8_ets_service::kMaxPayloadBytes;
+                pre_data->data[0] = std::byte{0x01};
+                (void)event.Send(std::move(sample));
+            }
+            score::mw::log::LogDebug() << "[tc8_ets_stub] notified all events";
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    skeleton.StopOfferService();
+    score::mw::log::LogInfo() << "[tc8_ets_stub] StopOfferService done; exiting";
+    return 0;
+}

--- a/tests/tc8_conformance/application/shared/BUILD.bazel
+++ b/tests/tc8_conformance/application/shared/BUILD.bazel
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "tc8_ets_service",
+    hdrs = ["tc8_ets_service.h"],
+    visibility = ["//tests/tc8_conformance/application/ets_stub:__pkg__"],
+    deps = [
+        "//score/serializer:pre_serialized_data",
+        "@score_communication//score/mw/com",
+    ],
+)

--- a/tests/tc8_conformance/application/shared/tc8_ets_service.h
+++ b/tests/tc8_conformance/application/shared/tc8_ets_service.h
@@ -1,0 +1,48 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+#ifndef TESTS_TC8_CONFORMANCE_APPLICATION_TC8_ETS_SERVICE_H
+#define TESTS_TC8_CONFORMANCE_APPLICATION_TC8_ETS_SERVICE_H
+
+#include <array>
+#include <cstdint>
+
+#include "score/mw/com/types.h"
+#include "score/serializer/pre_serialized_data.h"
+
+namespace tc8_ets_service {
+
+// Maximum raw payload carried inside each PreSerializedData slot (1 byte for TC8 uint8 events).
+inline constexpr std::size_t kMaxPayloadBytes{1U};
+
+// SHM slot type metadata: sized and aligned for PreSerializedData<kMaxPayloadBytes>
+// so that the NullSerializer can interpret each slot without data-format mismatch.
+inline constexpr score::mw::com::DataTypeMetaInfo kDataTypeMetaInfo{
+    score::someip_gateway::serializer::get_size_of_pre_serialized_data(kMaxPayloadBytes),
+    alignof(score::someip_gateway::serializer::PreSerializedData<0>)};
+
+inline constexpr std::array<score::mw::com::EventInfo, 9> kEvents = {{
+    {"TestEventUINT8", kDataTypeMetaInfo},
+    {"TestEventUINT8Array", kDataTypeMetaInfo},
+    {"TestEventUINT8Reliable", kDataTypeMetaInfo},
+    {"TestEventUINT8E2E", kDataTypeMetaInfo},
+    {"InterfaceVersion", kDataTypeMetaInfo},
+    {"TestFieldUINT8", kDataTypeMetaInfo},
+    {"TestFieldUINT8Array", kDataTypeMetaInfo},
+    {"TestFieldUINT8Reliable", kDataTypeMetaInfo},
+    {"TestEventUINT8Multicast", kDataTypeMetaInfo},
+}};
+
+}  // namespace tc8_ets_service
+
+#endif  // TESTS_TC8_CONFORMANCE_APPLICATION_TC8_ETS_SERVICE_H


### PR DESCRIPTION
This is PR 2 of 9 in the TC8 conformance test suite stack (split from #60).

Depends on: #213 (jorgecasal/tc8-build-infra), now merged into main.

Note: Replaces the previously proposed PR #214 (jorgecasal/tc8-someipd-standalone), which was closed. The score/someipd_tc8/ standalone binary approach was replaced by the ETS stub described below.

## Changes

score/someipd/main.cpp: migrate logging from std::cout to score::mw::log. No logic change.

tests/tc8_conformance/application/ -- new ETS stub DUT:
- shared/tc8_ets_service.h: service constants and event descriptors used by the stub
- ets_stub/tc8_ets_stub.cpp: binary that offers tc8_service via mw::com GenericSkeleton and sends periodic event notifications for TC8 test capture
- ets_stub/config/tc8_ets_stub_mw_com_config.json: mw::com manifest for the stub

The ETS stub is the DUT application for TC8 conformance testing. It offers tc8_service via mw::com GenericSkeleton. gatewayd and someipd still run in the test setup and bridge that service to the SOME/IP network so the TC8 ETS can connect to it. Compared to the previous approach (a standalone someipd_tc8 binary), the ETS stub sits at the application layer and has no direct dependency on vsomeip or the IPC bridge internals.

## Stack

| PR | Branch | Status |
|----|--------|--------|
| 1 | jorgecasal/tc8-build-infra | merged |
| 2 | jorgecasal/tc8-ets-stub-dut | this PR |
| 3 | jorgecasal/tc8-itf-migration | pending |
| 4 | jorgecasal/tc8-infra | pending |
| 5 | jorgecasal/tc8-sd-core | pending |
| 6 | jorgecasal/tc8-sd-compliance | pending |
| 7 | jorgecasal/tc8-msg-format | pending |
| 8 | jorgecasal/tc8-event-field | pending |
| 9 | jorgecasal/tc8-ci-docs | pending |

## Review focus

- tc8_ets_stub.cpp: does the mw::com GenericSkeleton offer/notify flow correctly implement the event patterns expected by TC8 tests?
- tc8_ets_service.h: are the event descriptors and DataTypeMetaInfo correct?
- tc8_ets_stub_mw_com_config.json: are service ID, instance ID, and event IDs consistent with the TC8 test configs?
- score/someipd/main.cpp: logging migration only, verify no logic regression.